### PR TITLE
Travis CI: Add Python 3.6 and 3.7 and upgrade to flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 sudo: false
 
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
   - "3.3"
@@ -13,9 +14,15 @@ python:
   - "pypy"
   - "pypy3"
 
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+
 install:
-  - pip install pylint pyflakes
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+  - pip install pylint flake8
+# command to install dependencies, e.g. pip install -r requirements.txt
 # install: "sudo apt-get install"
 # command to run tests, e.g. python setup.py test
 script:
@@ -23,10 +30,8 @@ script:
   - python cpplint_clitest.py
   - python cpplint.py --help
 
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pyflakes cpplint_unittest.py; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pyflakes cpplint_clitest.py; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pyflakes cpplint.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then flake8 --max-line-length=100 cpplint_unittest.py cpplint_clitest.py cpplint.py; fi
 
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pylint --max-locals=25 --max-line-length=100 --max-attributes=10 -d bad-indentation,invalid-name,too-many-statements,multiple-statements,global-statement,missing-docstring,too-many-branches,too-many-return-statements,too-many-arguments,fixme,bad-continuation,bad-option-value,redefined-builtin,too-few-public-methods,no-self-use,too-many-lines,too-many-function-args,unused-argument,anomalous-unicode-escape-in-string,too-many-boolean-expressions   cpplint.py; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pylint --max-locals=25 --max-line-length=100 --max-attributes=10 -d bad-indentation,invalid-name,too-many-statements,multiple-statements,global-statement,missing-docstring,too-many-branches,too-many-return-statements,too-many-arguments,fixme,bad-continuation,bad-option-value,redefined-builtin,too-few-public-methods,no-self-use,too-many-lines,too-many-function-args,unused-argument,anomalous-unicode-escape-in-string,too-many-boolean-expressions   cpplint_clitest.py; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pylint --max-locals=25 --max-line-length=120 --max-attributes=10 --max-public-methods=200 -d bad-indentation,invalid-name,too-many-statements,multiple-statements,global-statement,missing-docstring,too-many-branches,too-many-return-statements,too-many-arguments,fixme,bad-continuation,bad-option-value,redefined-builtin,too-few-public-methods,no-self-use,too-many-lines,too-many-function-args,unused-argument,protected-access,unused-variable,global-at-module-level,anomalous-unicode-escape-in-string   cpplint_unittest.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --max-locals=25 --max-line-length=100 --max-attributes=10 -d bad-indentation,invalid-name,too-many-statements,multiple-statements,global-statement,missing-docstring,too-many-branches,too-many-return-statements,too-many-arguments,fixme,bad-continuation,bad-option-value,redefined-builtin,too-few-public-methods,no-self-use,too-many-lines,too-many-function-args,unused-argument,anomalous-unicode-escape-in-string,too-many-boolean-expressions   cpplint.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --max-locals=25 --max-line-length=100 --max-attributes=10 -d bad-indentation,invalid-name,too-many-statements,multiple-statements,global-statement,missing-docstring,too-many-branches,too-many-return-statements,too-many-arguments,fixme,bad-continuation,bad-option-value,redefined-builtin,too-few-public-methods,no-self-use,too-many-lines,too-many-function-args,unused-argument,anomalous-unicode-escape-in-string,too-many-boolean-expressions   cpplint_clitest.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --max-locals=25 --max-line-length=120 --max-attributes=10 --max-public-methods=200 -d bad-indentation,invalid-name,too-many-statements,multiple-statements,global-statement,missing-docstring,too-many-branches,too-many-return-statements,too-many-arguments,fixme,bad-continuation,bad-option-value,redefined-builtin,too-few-public-methods,no-self-use,too-many-lines,too-many-function-args,unused-argument,protected-access,unused-variable,global-at-module-level,anomalous-unicode-escape-in-string   cpplint_unittest.py; fi


### PR DESCRIPTION
Flake8 is a superset of PyFlakes so it runs all the same tests and adds others from pycodestyle, McCabe Complexity, etc.