### PR TITLE
Add special case for std::set template usage

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -5533,7 +5533,7 @@ _HEADERS_CONTAINING_TEMPLATES = (
     ('<memory>', ('allocator', 'make_shared', 'make_unique', 'shared_ptr',
                   'unique_ptr', 'weak_ptr')),
     ('<queue>', ('queue', 'priority_queue',)),
-    ('<set>', ('set', 'multiset',)),
+    ('<set>', ('multiset',)),
     ('<stack>', ('stack',)),
     ('<string>', ('char_traits', 'basic_string',)),
     ('<tuple>', ('tuple',)),
@@ -5567,6 +5567,11 @@ for _header, _templates in _HEADERS_MAYBE_TEMPLATES:
         (re.compile(r'[^>.]\b' + _template + r'(<.*?>)?\([^\)]'),
             _template,
             _header))
+# Match set<type>, but not foo->set<type>, foo.set<type>
+_re_pattern_headers_maybe_templates.append(
+    (re.compile(r'[^>.]\bset\s*\<'),
+        'set<>',
+        '<set>'))
 
 # Other scripts may reach in and modify this pattern.
 _re_pattern_templates = []

--- a/cpplint.py
+++ b/cpplint.py
@@ -5529,7 +5529,7 @@ _HEADERS_CONTAINING_TEMPLATES = (
                      )),
     ('<limits>', ('numeric_limits',)),
     ('<list>', ('list',)),
-    ('<map>', ('map', 'multimap',)),
+    ('<map>', ('multimap',)),
     ('<memory>', ('allocator', 'make_shared', 'make_unique', 'shared_ptr',
                   'unique_ptr', 'weak_ptr')),
     ('<queue>', ('queue', 'priority_queue',)),
@@ -5572,6 +5572,11 @@ _re_pattern_headers_maybe_templates.append(
     (re.compile(r'[^>.]\bset\s*\<'),
         'set<>',
         '<set>'))
+# Match 'map<type> var' and 'std::map<type>(...)', but not 'map<type>(...)''
+_re_pattern_headers_maybe_templates.append(
+    (re.compile(r'(std\b::\bmap\s*\<)|(^(std\b::\b)map\b\(\s*\<)'),
+        'map<>',
+        '<map>'))
 
 # Other scripts may reach in and modify this pattern.
 _re_pattern_templates = []

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1125,6 +1125,22 @@ class CpplintTest(CpplintTestBase):
         bar.set<int>("int", 5);
         pbar->set<bool>("bool", false);""",
         '')
+    # False positive for std::map
+    self.TestIncludeWhatYouUse(
+        """
+        template <typename T>
+        struct Foo {
+            T t;
+        };
+        template <typename T>
+        Foo<T> map(T t) {
+            return Foo<T>{ t };
+        }
+        struct Bar {
+        };
+        auto res = map<Bar>();
+        """,
+        '')
 
     # Test the UpdateIncludeState code path.
     mock_header_contents = ['#include "blah/foo.h"', '#include "blah/bar.h"']

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1112,6 +1112,19 @@ class CpplintTest(CpplintTestBase):
         """,
         'Add #include <utility> for swap'
         '  [build/include_what_you_use] [4]')
+    # False positive for std::set
+    self.TestIncludeWhatYouUse(
+        """
+        #include <string>
+        struct Foo {
+            template <typename T>
+            void set(const std::string& name, const T& value);
+        };
+        Foo bar;
+        Foo* pbar = &bar;
+        bar.set<int>("int", 5);
+        pbar->set<bool>("bool", false);""",
+        '')
 
     # Test the UpdateIncludeState code path.
     mock_header_contents = ['#include "blah/foo.h"', '#include "blah/bar.h"']


### PR DESCRIPTION
Avoid false positive for `[build/include_what_you_use]` in case of `foo.set<type>` and `foo->set<type>` usage.

Fixes  https://github.com/google/styleguide/issues/410