### PR TITLE
Fixed false positive when -readability/alt_tokens is used

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -597,7 +597,7 @@ _ALT_TOKEN_REPLACEMENT = {
 # False positives include C-style multi-line comments and multi-line strings
 # but those have always been troublesome for cpplint.
 _ALT_TOKEN_REPLACEMENT_PATTERN = re.compile(
-    r'[ =()](' + ('|'.join(_ALT_TOKEN_REPLACEMENT.keys())) + r')(?=[ (]|$)')
+    r'([ =()])(' + ('|'.join(_ALT_TOKEN_REPLACEMENT.keys())) + r')([ (]|$)')
 
 
 # These constants define types of headers for use with
@@ -1603,6 +1603,28 @@ def CleanseComments(line):
   return _RE_PATTERN_CLEANSE_LINE_C_COMMENTS.sub('', line)
 
 
+def ReplaceAlternateTokens(line):
+  """Replace any alternate token by its original counterpart.
+
+  In order to comply with the google rule stating that unary operators should
+  never be followed by a space, an exception is made for the 'not' and 'compl'
+  alternate tokens. For these, any trailing space is removed during the
+  conversion.
+
+  Args:
+    line: The line being processed.
+
+  Returns:
+    The line with alternate tokens replaced.
+  """
+  for match in _ALT_TOKEN_REPLACEMENT_PATTERN.finditer(line):
+    replacement = _ALT_TOKEN_REPLACEMENT[match.group(2)]
+    tail = '' if match.group(2) in ['not', 'compl'] and match.group(3) == ' ' \
+           else r'\3'
+    line = re.sub(match.re, r'\1{}{}'.format(replacement, tail), line, count=1)
+  return line
+
+
 class CleansedLines(object):
   """Holds 4 copies of all lines with different preprocessing applied to them.
 
@@ -1615,15 +1637,17 @@ class CleansedLines(object):
   """
 
   def __init__(self, lines):
+    if '-readability/alt_tokens' in _cpplint_state.filters:
+      for i, line in enumerate(lines):
+        lines[i] = ReplaceAlternateTokens(line)
     self.elided = []
     self.lines = []
     self.raw_lines = lines
     self.num_lines = len(lines)
     self.lines_without_raw_strings = CleanseRawStrings(lines)
-    for linenum in range(len(self.lines_without_raw_strings)):
-      self.lines.append(CleanseComments(
-          self.lines_without_raw_strings[linenum]))
-      elided = self._CollapseStrings(self.lines_without_raw_strings[linenum])
+    for line in self.lines_without_raw_strings:
+      self.lines.append(CleanseComments(line))
+      elided = self._CollapseStrings(line)
       self.elided.append(CleanseComments(elided))
 
   def NumLines(self):
@@ -3275,7 +3299,8 @@ def CheckComment(line, filename, linenum, next_line_start, error):
                 '"// TODO(my_username): Stuff."')
 
         middle_whitespace = match.group(3)
-        # Comparisons made explicit for correctness -- pylint: disable=g-explicit-bool-comparison
+        # Comparisons made explicit for correctness
+        #  -- pylint: disable=g-explicit-bool-comparison
         if middle_whitespace != ' ' and middle_whitespace != '':
           error(filename, linenum, 'whitespace/todo', 2,
                 'TODO(my_username) should be followed by a space')
@@ -4423,7 +4448,7 @@ def CheckAltTokens(filename, clean_lines, linenum, error):
   for match in _ALT_TOKEN_REPLACEMENT_PATTERN.finditer(line):
     error(filename, linenum, 'readability/alt_tokens', 2,
           'Use operator %s instead of %s' % (
-              _ALT_TOKEN_REPLACEMENT[match.group(1)], match.group(1)))
+              _ALT_TOKEN_REPLACEMENT[match.group(2)], match.group(2)))
 
 
 def GetLineWidth(line):

--- a/cpplint.py
+++ b/cpplint.py
@@ -1618,10 +1618,10 @@ def ReplaceAlternateTokens(line):
     The line with alternate tokens replaced.
   """
   for match in _ALT_TOKEN_REPLACEMENT_PATTERN.finditer(line):
-    replacement = _ALT_TOKEN_REPLACEMENT[match.group(2)]
+    token = _ALT_TOKEN_REPLACEMENT[match.group(2)]
     tail = '' if match.group(2) in ['not', 'compl'] and match.group(3) == ' ' \
            else r'\3'
-    line = re.sub(match.re, r'\1{}{}'.format(replacement, tail), line, count=1)
+    line = re.sub(match.re, r'\1{}{}'.format(token, tail), line, count=1)
   return line
 
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -2589,6 +2589,39 @@ class CpplintTest(CpplintTestBase):
     self.TestLint('sizeof foo', '')
     self.TestLint('sizeof (foo)', '')
 
+  def testReplaceAlternateTokens(self):
+    assert cpplint.ReplaceAlternateTokens('tor or orc') == 'tor || orc'
+    assert cpplint.ReplaceAlternateTokens('orc or tor') == 'orc || tor'
+    assert cpplint.ReplaceAlternateTokens('tor or (orc)') == 'tor || (orc)'
+    assert cpplint.ReplaceAlternateTokens('tor or(orc)') == 'tor ||(orc)'
+    assert cpplint.ReplaceAlternateTokens('sand and(android)') == \
+                                          'sand &&(android)'
+    assert cpplint.ReplaceAlternateTokens('(sand) and (android)') == \
+                                          '(sand) && (android)'
+    assert cpplint.ReplaceAlternateTokens(' not note') == ' !note'
+    assert cpplint.ReplaceAlternateTokens(')not note') == ')!note'
+    assert cpplint.ReplaceAlternateTokens('(not note') == '(!note'
+    assert cpplint.ReplaceAlternateTokens(' not(note)') == ' !(note)'
+    assert cpplint.ReplaceAlternateTokens(' not (splinot)') == ' !(splinot)'
+    assert cpplint.ReplaceAlternateTokens('tor and orc or android') == \
+                                          'tor && orc || android'
+    assert cpplint.ReplaceAlternateTokens('tor or orc and ands not note') == \
+                                          'tor || orc && ands !note'
+
+  def testSpacingAfterAlternateToken(self):
+    try:
+      cpplint._cpplint_state.AddFilters('-readability/alt_tokens')
+      self.TestLint('if (foo or (bar) or foobar) {', '')
+      self.TestLint('if (foo or (bar)) {', '')
+      self.TestLint('if ((foo) or (bar)) {', '')
+      self.TestLint('if (not foo) {', '')
+      self.TestLint('if (not (foo)) {', '')
+      self.TestLint('if (not(foo)) {', '')
+      self.TestLint('if ((foo)or(bar)) {', 'Missing spaces around ||'
+                    '  [whitespace/operators] [3]')
+    finally:
+      cpplint._cpplint_state.SetFilters('')
+
   def testSpacingBeforeBraces(self):
     self.TestLint('if (foo){', 'Missing space before {'
                   '  [whitespace/braces] [5]')


### PR DESCRIPTION
In our organization, the use of alternate tokens (mostly ```and```, ```or``` and ```not```) is encouraged, for they allow the creation of more modern looking and readable code. In order to use cpplint with such files, the alternate tokens errors must be disabled (using the ```-readability/alt_tokens``` filter).
When disabled, cpplint will then report false positives for some legitimate constructs. For example, the line
```
if (a or (b + c)) {
```
will trigger a
```
Extra space before ( in function call  [whitespace/parens] [4]
```
error. In that case, cpplint is confusing the ```or``` token for a function name.
This branch alleviates the problem by replacing all alternate tokens by their original counterpart, so that the cpplint engine will handle them normally. The replacements are made only if the ```-readability/alt_tokens``` filter is provided, so should not affect the normal program use. One drawback of this implementation is that legitimate errors, such as one triggered by
```
if ((foo)or(bar)) {
```
are reported using the original tokens, i.e.
```
Missing spaces around || [whitespace/operators] [3]
```
so might be a little confusing for the unaware user. But for me this is well compensated by the fact that alternate tokens can be used more properly (without enabling the ```-whitespace/parens``` filter).

Unit tests were added to validate the modifications.

Both ```./cpplint_unittest.py``` and ```./cpplint_clitest.py``` are passing.