### PR TITLE
Extend class decl regexp to match V8's decorators

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -2771,7 +2771,7 @@ class NestingState(object):
     #   };
     class_decl_match = Match(
         r'^(\s*(?:template\s*<[\w\s<>,:=]*>\s*)?'
-        r'(class|struct)\s+(?:[A-Z_]+\s+)*(\w+(?:::\w+)*))'
+        r'(class|struct)\s+(?:[A-Z0-9_]+\s+)*(\w+(?:::\w+)*))'
         r'(.*)$', line)
     if (class_decl_match and
         (not self.stack or self.stack[-1].open_parentheses == 0)):


### PR DESCRIPTION
This also allows digits in class decorators, to also match macros like
V8_EXPORT_PRIVATE.