### PR TITLE
Use stdout for PrintInfo

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -1074,7 +1074,7 @@ class _CppLintState(object):
 
   def PrintInfo(self, message):
     if not _quiet and self.output_format != 'junit':
-      sys.stderr.write(message)
+      sys.stdout.write(message)
 
   def PrintError(self, message):
     if self.output_format == 'junit':


### PR DESCRIPTION
Instead of printing everything to stderr, it is more useful to just print warnings there. And print the additionally informing stuff to stdout. This also helps tools to read the warnings (like the QtCreator).