### PR TITLE
Differentiate namespace headers

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -282,6 +282,7 @@ _ERROR_CATEGORIES = [
     'build/include_alpha',
     'build/include_order',
     'build/include_what_you_use',
+    'build/namespaces_headers',
     'build/namespaces_literals',
     'build/namespaces',
     'build/printf_format',
@@ -5084,7 +5085,7 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
   if (IsHeaderExtension(file_extension)
       and Search(r'\bnamespace\s*{', line)
       and line[-1] != '\\'):
-    error(filename, linenum, 'build/namespaces', 4,
+    error(filename, linenum, 'build/namespaces_headers', 4,
           'Do not use unnamed namespaces in header files.  See '
           'https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces'
           ' for more information.')

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4255,7 +4255,7 @@ class CpplintTest(CpplintTestBase):
         'foo.' + extension, 'namespace {',
         'Do not use unnamed namespaces in header files.  See'
         ' https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces'
-        ' for more information.  [build/namespaces] [4]')
+        ' for more information.  [build/namespaces_headers] [4]')
     # namespace registration macros are OK.
     self.TestLanguageRulesCheck('foo.' + extension, 'namespace {  \\', '')
     # named namespaces are OK.


### PR DESCRIPTION
Similar to https://github.com/cpplint/cpplint/pull/15, it would be nice to be able to turn off the rules specific to namespaces in header files. It's generally useful for header only implementations. 

More detailed explanations:
https://github.com/nlohmann/json/issues/552
https://stackoverflow.com/a/358823