### PR TITLE
Fix for false positive on QT's "public slots:" lines.

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -4575,7 +4575,7 @@ def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
   # if(match($0, " <<")) complain = 0;
   # if(match(prev, " +for \\(")) complain = 0;
   # if(prevodd && match(prevprev, " +for \\(")) complain = 0;
-  scope_or_label_pattern = r'\s*(\w+|private slots)\s*:\s*\\?$'
+  scope_or_label_pattern = r'\s*(\w+|(public|private|protected) slots)\s*:\s*\\?$'
   classinfo = nesting_state.InnermostClass()
   initial_spaces = 0
   cleansed_line = clean_lines.elided[linenum]

--- a/cpplint.py
+++ b/cpplint.py
@@ -4575,7 +4575,7 @@ def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
   # if(match($0, " <<")) complain = 0;
   # if(match(prev, " +for \\(")) complain = 0;
   # if(prevodd && match(prevprev, " +for \\(")) complain = 0;
-  scope_or_label_pattern = r'\s*\w+\s*:\s*\\?$'
+  scope_or_label_pattern = r'\s*(\w+|private slots)\s*:\s*\\?$'
   classinfo = nesting_state.InnermostClass()
   initial_spaces = 0
   cleansed_line = clean_lines.elided[linenum]

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3666,8 +3666,7 @@ class CpplintTest(CpplintTestBase):
              public slots:
               void bar();
             };"""),
-        'Weird number of spaces at line-start.  '
-        'Are you using a 2-space indent?  [whitespace/indent] [3]')
+        '')
     self.TestMultiLineLint(
         TrimExtraIndent('''
             static const char kRawString[] = R"("


### PR DESCRIPTION
Source code like:
```
class X : public QObject {
 ...
 public slots:
 ...
}
```

using the `slots` macro, causes incorrectly message "Weird number of spaces at line-start. Are you using a 2-space indent? [whitespace/indent] [3]".

The fix is originally from @tkruse : https://github.com/tkruse/cpplint/pull/8/commits/64d591a61d658074ee43b9e88a33bf4230889716