### PR TITLE
whitespace/parens - Extra space before ( in function call, Operator overloading

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -3220,14 +3220,16 @@ def CheckSpacingForFunctionCall(filename, clean_lines, linenum, error):
         not Search(r'#\s*define|typedef|using\s+\w+\s*=', fncall) and
         not Search(r'\w\s+\((\w+::)*\*\w+\)\(', fncall) and
         not Search(r'\bcase\s+\(', fncall)):
-      # TODO(unknown): Space after an operator function seem to be a common
-      # error, silence those for now by restricting them to highest verbosity.
-      if Search(r'\boperator_*\b', line):
-        error(filename, linenum, 'whitespace/parens', 0,
-              'Extra space before ( in function call')
-      else:
-        error(filename, linenum, 'whitespace/parens', 4,
-              'Extra space before ( in function call')
+      error(filename, linenum, 'whitespace/parens', 4,
+            'Extra space before ( in function call')
+    # Operator overloading
+    # Do not overload &&, ||, , (comma), or unary &.
+    # Do not overload operator"", i.e. do not introduce user-defined literals.
+    if Search(r'\boperator(\+|\-|\*|\/|%|^|&|\||~|!|,|=|<|>|<=|>=|\+\+|\-\-|'
+              r'<<|>>|==|!=|&&|\|\||\+=|\-=|\/=|%=|\^=|&=|\|=|\*=|<<=|>>=|'
+              r'\[\]|\(\)|\->|\->\*)\s+', fncall):
+      error(filename, linenum, 'whitespace/parens', 4,
+            'Extra space before ( in function call')
     # If the ) is followed only by a newline or a { + newline, assume it's
     # part of a control statement (if/while/etc), and don't complain
     if Search(r'[^)]\s+\)\s*[^{\s]', fncall):


### PR DESCRIPTION
    # Operator overloading    
    # Do not overload &&, ||, , (comma), or unary &.
    # Do not overload operator, i.e. do not introduce user-defined literals.