### PR TITLE
fix #112, identifying of copy constructors 

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -3144,7 +3144,8 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
         Search(r'\bstd\s*::\s*initializer_list\b', constructor_args[0]))
     copy_constructor = bool(
         onearg_constructor and
-        Match(r'(const\s+)?%s(\s*<[^>]*>)?(\s+const)?\s*(?:<\w+>\s*)?&'
+        Match(r'((const\s+(volatile\s+)?)?|(volatile\s+(const\s+)?))?'
+              r'%s(\s*<[^>]*>)?(\s+const)?\s*(?:<\w+>\s*)?&'
               % re.escape(base_classname), constructor_args[0].strip()))
 
     if (not is_marked_explicit and

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1672,6 +1672,24 @@ class CpplintTest(CpplintTestBase):
       self.TestMultiLineLint(
           """
           class Foo {
+            Foo(volatile Foo&);
+          };""",
+          '')
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            Foo(volatile const Foo&);
+          };""",
+          '')
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            Foo(const volatile Foo&);
+          };""",
+          '')
+      self.TestMultiLineLint(
+          """
+          class Foo {
             Foo(Foo const&);
           };""",
           '')


### PR DESCRIPTION
match should allow combinations of volatile and const (#112).

> According to C++ [specification](https://en.cppreference.com/w/cpp/language/copy_constructor):
>A copy constructor of class T is a non-template constructor whose first parameter is T&‍, const T&‍, volatile T&‍, or const volatile T&‍, and either there are no other parameters, or the rest of the parameters all have default values.

The file `cpplint/cpplint.py` line number 3147 should be modified.

From: `Match(r'(const\s+)?%s(\s*<[^>]*>)?(\s+const)?\s*(?:<\w+>\s*)?&'`

To: `Match(r'((?:const|volatile|const\s+volatile|volatile\s+const)\s+)?%s(\s*<[^>]*>)?(\s+const)?\s*(?:<\w+>\s*)?&'`

To prevent false positive ccplint error:
> error cpplint: [runtime/explicit] Single-parameter constructors should be marked explicit.

When copy constructor is defined like:
`MyClass(volatile MyClass& rhs)`
`MyClass(const volatile MyClass& rhs);`
`MyClass(volatile const MyClass& rhs);`
