### PR TITLE
Avoid false positive warnings for QT signals and slots extended syntax.

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -4803,7 +4803,7 @@ def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
   # if(match($0, " <<")) complain = 0;
   # if(match(prev, " +for \\(")) complain = 0;
   # if(prevodd && match(prevprev, " +for \\(")) complain = 0;
-  scope_or_label_pattern = r'\s*\w+\s*:\s*\\?$'
+  scope_or_label_pattern = r'\s*(?:public|private|protected|signals)(?:\s+(?:slots\s*)?)?:\s*\\?$'
   classinfo = nesting_state.InnermostClass()
   initial_spaces = 0
   cleansed_line = clean_lines.elided[linenum]

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3712,14 +3712,31 @@ class CpplintTest(CpplintTestBase):
     self.TestLint(' protected: \\', '')
     self.TestLint('  public:      \\', '')
     self.TestLint('   private:   \\', '')
+    # examples using QT signals/slots macro
     self.TestMultiLineLint(
         TrimExtraIndent("""
             class foo {
              public slots:
               void bar();
+             signals:
             };"""),
-        'Weird number of spaces at line-start.  '
-        'Are you using a 2-space indent?  [whitespace/indent] [3]')
+        '')
+    self.TestMultiLineLint(
+        TrimExtraIndent("""
+            class foo {
+              public slots:
+              void bar();
+            };"""),
+        'public slots: should be indented +1 space inside class foo'
+        '  [whitespace/indent] [3]')
+    self.TestMultiLineLint(
+        TrimExtraIndent("""
+            class foo {
+              signals:
+              void bar();
+            };"""),
+        'signals: should be indented +1 space inside class foo'
+        '  [whitespace/indent] [3]')
     self.TestMultiLineLint(
         TrimExtraIndent('''
             static const char kRawString[] = R"("


### PR DESCRIPTION
supercedes https://github.com/cpplint/cpplint/pull/99

So coming back to this after years... 
The original testcase changed in this MR had been added in a8ee7eaaa4e467, and it uses the "slots" macro:

```
class foo {
 public slots:
  void bar();
}
```
Since that commit is a batch commit of many individual changes mentioned in the commit comment, it is unclear how this new testcase was justified, and why an original author thought this would be a good lint warning for this situation.

In cpplint.py there is another place that considers QT "signals:" and "public slots:" 
```
access_match = Match(
fd5da634 cpplint/cpplint.py (erg@google.com          2013-10-25 17:39:45 +0000 3041)           r'^(.*)\b(public|private|protected|signals)(\s+(?:slots\s*)?)?'
```