### PR TITLE
Add language about Unix directory aliases (fixes #139)

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -2437,16 +2437,22 @@ def CheckHeaderFileIncluded(filename, include_state, error):
       continue
     headername = FileInfo(headerfile).RepositoryName()
     first_include = None
+    include_uses_unix_dir_aliases = False
     for section_list in include_state.include_list:
       for f in section_list:
-        if headername in f[0] or f[0] in headername:
+        include_text = f[0]
+        if "./" in include_text:
+          include_uses_unix_dir_aliases = True
+        if headername in include_text or include_text in headername:
           return
         if not first_include:
           first_include = f[1]
 
-    error(filename, first_include, 'build/include', 5,
-          '%s should include its header file %s' % (fileinfo.RepositoryName(),
-                                                    headername))
+    message = '%s should include its header file %s' % (fileinfo.RepositoryName(), headername)
+    if include_uses_unix_dir_aliases:
+      message += ". Unix directory aliases like '.' and '..' are not allowed."
+
+    error(filename, first_include, 'build/include', 5, message)
 
 
 def CheckForBadCharacters(filename, lines, error):

--- a/cpplint.py
+++ b/cpplint.py
@@ -2450,7 +2450,7 @@ def CheckHeaderFileIncluded(filename, include_state, error):
 
     message = '%s should include its header file %s' % (fileinfo.RepositoryName(), headername)
     if include_uses_unix_dir_aliases:
-      message += ". Unix directory aliases like . and .. are not allowed."
+      message += ". Relative paths like . and .. are not allowed."
 
     error(filename, first_include, 'build/include', 5, message)
 

--- a/cpplint.py
+++ b/cpplint.py
@@ -2450,7 +2450,7 @@ def CheckHeaderFileIncluded(filename, include_state, error):
 
     message = '%s should include its header file %s' % (fileinfo.RepositoryName(), headername)
     if include_uses_unix_dir_aliases:
-      message += ". Unix directory aliases like '.' and '..' are not allowed."
+      message += ". Unix directory aliases like . and .. are not allowed."
 
     error(filename, first_include, 'build/include', 5, message)
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4812,6 +4812,23 @@ class CpplintTest(CpplintTestBase):
         0,
         error_collector.Results().count(expected))
 
+      # Unix directory aliases are not allowed, and should trigger the
+      # "include itse header file" error
+      error_collector = ErrorCollector(self.assertTrue)
+      cpplint.ProcessFileData(
+        'test/foo.cc', 'cc',
+        [r'#include "./test/foo.h"',
+         ''
+         ],
+        error_collector)
+      expected = "{dir}/{fn}.cc should include its header file {dir}/{fn}{unix_text}  [build/include] [5]".format(
+          fn="foo",
+          dir=test_directory,
+          unix_text=". Unix directory aliases like '.' and '..' are not allowed.")
+      self.assertEqual(
+        1,
+        error_collector.Results().count(expected))
+
       # This should continue to work
       error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData(

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4824,7 +4824,7 @@ class CpplintTest(CpplintTestBase):
       expected = "{dir}/{fn}.cc should include its header file {dir}/{fn}{unix_text}  [build/include] [5]".format(
           fn="foo",
           dir=test_directory,
-          unix_text=". Unix directory aliases like '.' and '..' are not allowed.")
+          unix_text=". Unix directory aliases like . and .. are not allowed.")
       self.assertEqual(
         1,
         error_collector.Results().count(expected))

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4821,7 +4821,7 @@ class CpplintTest(CpplintTestBase):
          ''
          ],
         error_collector)
-      expected = "{dir}/{fn}.cc should include its header file {dir}/{fn}{unix_text}  [build/include] [5]".format(
+      expected = "{dir}/{fn}.cc should include its header file {dir}/{fn}.h{unix_text}  [build/include] [5]".format(
           fn="foo",
           dir=test_directory,
           unix_text=". Relative paths like . and .. are not allowed.")

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4824,7 +4824,7 @@ class CpplintTest(CpplintTestBase):
       expected = "{dir}/{fn}.cc should include its header file {dir}/{fn}{unix_text}  [build/include] [5]".format(
           fn="foo",
           dir=test_directory,
-          unix_text=". Unix directory aliases like . and .. are not allowed.")
+          unix_text=". Relative paths like . and .. are not allowed.")
       self.assertEqual(
         1,
         error_collector.Results().count(expected))


### PR DESCRIPTION
Thanks for this great project! `cpplint` has helped us a lot in [LightGBM](https://github.com/microsoft/LightGBM).

This pull request attempts to address https://github.com/cpplint/cpplint/issues/139#issuecomment-629594423. See the conversation on that issue for background.

Essentially, if `something.cpp` uses `#include "./something.h"`, it can generate the warning

> src/foo.cpp:2: src/something.cpp should include its header file src/something.h [build/include] [5]

That message might be confusing to people (like me) who didn't know that Unix directory aliases like `./` are not allowed by the Google style guide.

This PR adds a more informative warning for such cases.

Thanks for your time and consideration!