### PR TITLE
[ci] use portable temp directory approach in tests (fixes #154)

### DIFF
--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -83,7 +83,7 @@ class TemporaryFolderClassSetup(object):
     def setUpClass(cls):
         """setup tmp folder for testing with samples and custom additions by subclasses"""
         try:
-            cls._root = tempfile.mkdtemp()
+            cls._root = os.path.realpath(tempfile.mkdtemp())
             shutil.copytree('samples', os.path.join(cls._root, 'samples'))
             cls.prepare_directory(cls._root)
         except Exception as e:

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4134,7 +4134,7 @@ class CpplintTest(CpplintTestBase):
 
   def testRecursiveArgument(self):
     working_dir = os.getcwd()
-    temp_dir = tempfile.mkdtemp()
+    temp_dir = os.path.realpath(tempfile.mkdtemp())
     try:
       src_dir = os.path.join(temp_dir, "src")
       nested_dir = os.path.join(temp_dir, "src", "nested")
@@ -4154,7 +4154,7 @@ class CpplintTest(CpplintTestBase):
 
   def testRecursiveExcludeInvalidFileExtension(self):
     working_dir = os.getcwd()
-    temp_dir = tempfile.mkdtemp()
+    temp_dir = os.path.realpath(tempfile.mkdtemp())
     try:
       src_dir = os.path.join(temp_dir, "src")
       os.makedirs(src_dir)
@@ -4175,7 +4175,7 @@ class CpplintTest(CpplintTestBase):
 
   def testRecursiveExclude(self):
     working_dir = os.getcwd()
-    temp_dir = tempfile.mkdtemp()
+    temp_dir = os.path.realpath(tempfile.mkdtemp())
     try:
       src_dir = os.path.join(temp_dir, 'src')
       src2_dir = os.path.join(temp_dir, 'src2')
@@ -4688,7 +4688,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEquals([], error_collector.ResultList())
 
   def testBuildHeaderGuardWithRoot(self):
-    temp_directory = tempfile.mkdtemp()
+    temp_directory = os.path.realpath(tempfile.mkdtemp())
     try:
       test_directory = os.path.join(temp_directory, "test")
       os.makedirs(test_directory)
@@ -4794,7 +4794,7 @@ class CpplintTest(CpplintTestBase):
     os.chdir(cur_dir)
 
   def testIncludeItsHeader(self):
-    temp_directory = tempfile.mkdtemp()
+    temp_directory = os.path.realpath(tempfile.mkdtemp())
     cur_dir = os.getcwd()
     try:
       test_directory = os.path.join(temp_directory, "test")
@@ -4895,8 +4895,8 @@ class CpplintTest(CpplintTestBase):
                       cpplint.PathSplitToList(os.path.join('a', 'b', 'c', 'd')))
 
   def testBuildHeaderGuardWithRepository(self):
-    temp_directory = tempfile.mkdtemp()
-    temp_directory2 = tempfile.mkdtemp()
+    temp_directory = os.path.realpath(tempfile.mkdtemp())
+    temp_directory2 = os.path.realpath(tempfile.mkdtemp())
     try:
       os.makedirs(os.path.join(temp_directory, ".svn"))
       trunk_dir = os.path.join(temp_directory, "trunk")
@@ -6413,7 +6413,7 @@ class NestingStateTest(unittest.TestCase):
 class QuietTest(unittest.TestCase):
 
   def setUp(self):
-    self.temp_dir = tempfile.mkdtemp()
+    self.temp_dir = os.path.realpath(tempfile.mkdtemp())
     self.this_dir_path = os.path.abspath(self.temp_dir)
     self.python_executable = sys.executable or 'python'
     self.cpplint_test_h = os.path.join(self.this_dir_path,


### PR DESCRIPTION
This PR proposes a fix for the issue detailed in #154 .

@tkruse I followed your suggestion in https://github.com/cpplint/cpplint/issues/154#issuecomment-651461935 and it worked! On my Mac, as of this fix running `./setup.py test` now succeeds!

https://github.com/cpplint/cpplint/issues/154#issuecomment-651461935
![image](https://user-images.githubusercontent.com/7608904/87116530-a7a9bf00-c23b-11ea-90aa-70dc461d4b3b.png)
