### PR TITLE
Fix --root option under Windows

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -2337,7 +2337,7 @@ def GetHeaderGuardCPPVariable(filename):
 
     #   --root=.. , will prepend the outer directory to the header guard
     full_path = fileinfo.FullName()
-    root_abspath = os.path.abspath(_root)
+    root_abspath = os.path.abspath(_root).replace('\\', '/')
 
     maybe_path = StripListPrefix(PathSplitToList(full_path),
                                  PathSplitToList(root_abspath))


### PR DESCRIPTION
Credit goes to https://github.com/google/styleguide/pull/346 for determining this fix. My team has had cpplint failures on Windows because of cpplint not handling paths correctly.