### PR TITLE
add elif as an exception for CheckSpacingForFunctionCall()

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -3472,7 +3472,7 @@ def CheckSpacingForFunctionCall(filename, clean_lines, linenum, error):
   # Note that we assume the contents of [] to be short enough that
   # they'll never need to wrap.
   if (  # Ignore control structures.
-      not Search(r'\b(if|for|while|switch|return|new|delete|catch|sizeof)\b',
+      not Search(r'\b(if|elif|for|while|switch|return|new|delete|catch|sizeof)\b',
                  fncall) and
       # Ignore pointers/references to functions.
       not Search(r' \([^)]+\)\([^)]*(\)|,$)', fncall) and

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4038,6 +4038,22 @@ class CpplintTest(CpplintTestBase):
               [] { if (true); });
         }""",
         '')
+    self.TestMultiLineLint(
+        """
+        #if(A == 0)
+          foo();
+        #elif(A == 1)
+          bar();
+        #endif""",
+        '')
+    self.TestMultiLineLint(
+        """
+        #if (A == 0)
+          foo();
+        #elif (A == 1)
+          bar();
+        #endif""",
+        '')
 
   def testTab(self):
     self.TestLint('\tint a;',
@@ -6097,7 +6113,7 @@ class NestingStateTest(unittest.TestCase):
     self.assertEquals(self.nesting_state.stack[0].class_indent, 0)
     self.UpdateWithLines(['}'])
     self.assertEquals(len(self.nesting_state.stack), 0)
-    
+
   def testClass(self):
     self.UpdateWithLines(['class A {'])
     self.assertEquals(len(self.nesting_state.stack), 1)

--- a/dev-requirements
+++ b/dev-requirements
@@ -6,6 +6,7 @@ flake8-polyfill
 pylint>=1.8.4
 tox>=3.0.0
 tox-pyenv
+importlib-metadata>=0.12
 
 # Below only run with python3, installed in tox.ini
 # mypy

--- a/dev-requirements
+++ b/dev-requirements
@@ -2,6 +2,7 @@
 
 # also change in tox.ini
 flake8>=3.7.8
+flake8-polyfill
 pylint>=1.8.4
 tox>=3.0.0
 tox-pyenv

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ deps =
   py36: radon>=2.4.0
   py36: pylint>=1.8.4
   py36: flake8-polyfill
+  py35: importlib-metadata>=0.12
+  py27: importlib-metadata>=0.12
+  pypy: importlib-metadata>=0.12
 
 commands =
   {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
   py36: flake8>=3.7.8
   py36: radon>=2.4.0
   py36: pylint>=1.8.4
+  py36: flake8-polyfill
 
 commands =
   {envpython} setup.py test


### PR DESCRIPTION
The current version of the code allows for white spaces after preprocessor directive `#if (FOO == 1)` but not after `#elif (FOO == 1)`.

The code below will throw this error: test.cpp:4:  Extra space before ( in function call  [whitespace/parens] [4]

```
int main() {
#if (A == 0)
    foo();
#elif (A == 1)
    bar();
#endif
return 0;
}
```
This pull request fixes that.