### PR TITLE
Added 'size_t' to typecasts detected by CheckCStyleCast

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -5752,7 +5752,7 @@ def CheckCasts(filename, clean_lines, linenum, error):
 
   if not expecting_function:
     CheckCStyleCast(filename, clean_lines, linenum, 'static_cast',
-                    r'\((int|float|double|bool|char|u?int(16|32|64))\)', error)
+                    r'\((int|float|double|bool|char|u?int(16|32|64)|size_t)\)', error)
 
   # This doesn't catch all cases. Consider (const char * const)"hello".
   #

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -632,6 +632,10 @@ class CpplintTest(CpplintTestBase):
         'uint64 a = (uint64)1.0;',
         'Using C-style cast.  Use static_cast<uint64>(...) instead'
         '  [readability/casting] [4]')
+    self.TestLint(
+        'size_t a = (size_t)1.0;',
+        'Using C-style cast.  Use static_cast<size_t>(...) instead'
+        '  [readability/casting] [4]')
 
     # These shouldn't be recognized casts.
     self.TestLint('u a = (u)NULL;', '')


### PR DESCRIPTION
Trivial PR .. but cpplint was not detecting `(size_t)` casts in my codebase