### PR TITLE
Sort extension list in help (today the order is random)

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -6687,10 +6687,10 @@ def PrintUsage(message):
   Args:
     message: The optional error message.
   """
-  sys.stderr.write(_USAGE  % (list(GetAllExtensions()),
-       ','.join(list(GetAllExtensions())),
-       GetHeaderExtensions(),
-       ','.join(GetHeaderExtensions())))
+  sys.stderr.write(_USAGE  % (sorted(list(GetAllExtensions())),
+       ','.join(sorted(list(GetAllExtensions()))),
+       sorted(GetHeaderExtensions()),
+       ','.join(sorted(GetHeaderExtensions()))))
 
   if message:
     sys.exit('\nFATAL ERROR: ' + message)


### PR DESCRIPTION
[Mega-Linter](https://github.com/nvuillam/mega-linter) generates its help from cpplint --help

An automated job detects when there is a new version of help and triggers actions from this event
But as the list of returned extensions is random for every cpplint --help called, the result is never the same and there are false updates detection 

Sorting the list of extensions will make help text to be always the same for the same version :)