### PR TITLE
Handle Other Header Files for Build Include Subdir

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -5068,10 +5068,12 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
   #
   # We also make an exception for Lua headers, which follow google
   # naming convention but not the include convention.
-  match = Match(r'#include\s*"([^/]+\.h)"', line)
-  if match and not _THIRD_PARTY_HEADERS_PATTERN.match(match.group(1)):
-    error(filename, linenum, 'build/include_subdir', 4,
-          'Include the directory when naming .h files')
+  match = Match(r'#include\s*"([^/]+\.(.*))"', line)
+  if match:
+    if (IsHeaderExtension(match.group(2)) and
+        not _THIRD_PARTY_HEADERS_PATTERN.match(match.group(1))):
+      error(filename, linenum, 'build/include_subdir', 4,
+            'Include the directory when naming header files')
 
   # we shouldn't include a file more than once. actually, there are a
   # handful of instances where doing so is okay, but in general it's

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4971,8 +4971,13 @@ class CpplintTest(CpplintTestBase):
   def testBuildInclude(self):
     # Test that include statements have slashes in them.
     self.TestLint('#include "foo.h"',
-                  'Include the directory when naming .h files'
+                  'Include the directory when naming header files'
                   '  [build/include_subdir] [4]')
+    self.TestLint('#include "bar.hh"',
+                  'Include the directory when naming header files'
+                  '  [build/include_subdir] [4]')
+    self.TestLint('#include "baz.aa"', '')
+    self.TestLint('#include "dir/foo.h"', '')
     self.TestLint('#include "Python.h"', '')
     self.TestLint('#include "lua.h"', '')
 


### PR DESCRIPTION
build/include_subdir should handle arbitrarily header file extensions.

Tests
```
#include "test.hh" // now emits warning with default header extensions
#include "test.h"  // same warning with default header extensions
#include "test.aa" // can emit warning if .aa is set as header extension
```