### PR TITLE
Fix issue when function arguments with mutiply class or struct keywords

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -3225,7 +3225,7 @@ class NestingState(object):
         # already saw a closing parenthesis, then these are probably
         # function arguments with extra "class" or "struct" keywords.
         # Also pop these stack for these.
-        if not self.SeenOpenBrace():
+        while not self.SeenOpenBrace():
           self.stack.pop()
       else:  # token == '}'
         # Perform end of block checks and pop the stack.


### PR DESCRIPTION
Issue introduction:
CPPLint already have protection when function arguments with extra "class" or "struct" keywords, following scenario is fine:

          struct demo_struct {
              int field;
          };
          
          void demo_issue(int num,
              struct demo_struct const *new_struct1,
              )
          {
              return 0;
          }

But in case multiply "struct" function arguments existed in a function like below(add "new_struct2" parameter):

          struct demo_struct {
              int field;
          };
          
          void demo_issue(int num,
              struct demo_struct const *new_struct1,
              struct demo_struct const *new_struct2  
              )
          {
              return 0;
          }

 It will cause false positive reporting as below:
demo.cpp:11:  Closing brace should be aligned with beginning of struct demo_struct  [whitespace/indent] [3]

Issue analysis:
In case meet multiply struct parameters, will push "_ClassInfo" instances mutiply times into the "stack" array of NestingState class ,
when ";" or ")" token is encountered before OpenBrace is not seen, will pop ONLY one "_ClassInfo" instance from the stack.
that makes at least one "struct" parameters be regarded as a "_ClassInfo" block but not a "struct" parameter. Then produce above warning.

Issue reslove:
Greedy pop the "_ClassInfo" instance from the stack until "_ClassInfo" instance have open brace when ";" or ")" token is encountered.
