### PR TITLE
handle other header files for build include subdir

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.6.0 (2022-02-19)
+-----
+
+* Fix #188: "Include the directory when naming header files" also for header files with other names like "*.hpp"
+
 1.5.5 (2021-05-20)
 -----
 

--- a/cpplint.py
+++ b/cpplint.py
@@ -5074,10 +5074,12 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
   #
   # We also make an exception for Lua headers, which follow google
   # naming convention but not the include convention.
-  match = Match(r'#include\s*"([^/]+\.h)"', line)
-  if match and not _THIRD_PARTY_HEADERS_PATTERN.match(match.group(1)):
-    error(filename, linenum, 'build/include_subdir', 4,
-          'Include the directory when naming .h files')
+  match = Match(r'#include\s*"([^/]+\.(.*))"', line)
+  if match:
+    if (IsHeaderExtension(match.group(2)) and
+        not _THIRD_PARTY_HEADERS_PATTERN.match(match.group(1))):
+      error(filename, linenum, 'build/include_subdir', 4,
+            'Include the directory when naming header files')
 
   # we shouldn't include a file more than once. actually, there are a
   # handful of instances where doing so is okay, but in general it's

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4968,8 +4968,13 @@ class CpplintTest(CpplintTestBase):
   def testBuildInclude(self):
     # Test that include statements have slashes in them.
     self.TestLint('#include "foo.h"',
-                  'Include the directory when naming .h files'
+                  'Include the directory when naming header files'
                   '  [build/include_subdir] [4]')
+    self.TestLint('#include "bar.hh"',
+                  'Include the directory when naming header files'
+                  '  [build/include_subdir] [4]')
+    self.TestLint('#include "baz.aa"', '')
+    self.TestLint('#include "dir/foo.h"', '')
     self.TestLint('#include "Python.h"', '')
     self.TestLint('#include "lua.h"', '')
 

--- a/samples/boost-sample/exclude.def
+++ b/samples/boost-sample/exclude.def
@@ -3,9 +3,10 @@
 4
 Done processing src/inspect/unnamed_namespace_check.hpp
 Done processing src/tr1/c_policy.hpp
-Total errors found: 106
+Total errors found: 107
 
 src/inspect/unnamed_namespace_check.hpp:0:  No #ifndef header guard found, suggested CPP variable is: SAMPLES_BOOST_SAMPLE_SRC_INSPECT_UNNAMED_NAMESPACE_CHECK_HPP_  [build/header_guard] [5]
+src/inspect/unnamed_namespace_check.hpp:11:  Include the directory when naming header files  [build/include_subdir] [4]
 src/inspect/unnamed_namespace_check.hpp:14:  Do not use unnamed namespaces in header files.  See https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces for more information.  [build/namespaces_headers] [4]
 src/inspect/unnamed_namespace_check.hpp:18:  At least two spaces is best between code and comments  [whitespace/comments] [2]
 src/inspect/unnamed_namespace_check.hpp:19:  Closing ) should be moved to the previous line  [whitespace/parens] [2]

--- a/samples/boost-sample/headers_inspect.def
+++ b/samples/boost-sample/headers_inspect.def
@@ -2,9 +2,10 @@ src/inspect/*
 1
 3
 Done processing src/inspect/unnamed_namespace_check.hpp
-Total errors found: 40
+Total errors found: 41
 
 src/inspect/unnamed_namespace_check.hpp:0:  No #ifndef header guard found, suggested CPP variable is: SAMPLES_BOOST_SAMPLE_SRC_INSPECT_UNNAMED_NAMESPACE_CHECK_HPP_  [build/header_guard] [5]
+src/inspect/unnamed_namespace_check.hpp:11:  Include the directory when naming header files  [build/include_subdir] [4]
 src/inspect/unnamed_namespace_check.hpp:14:  Do not use unnamed namespaces in header files.  See https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces for more information.  [build/namespaces_headers] [4]
 src/inspect/unnamed_namespace_check.hpp:18:  At least two spaces is best between code and comments  [whitespace/comments] [2]
 src/inspect/unnamed_namespace_check.hpp:19:  Closing ) should be moved to the previous line  [whitespace/parens] [2]

--- a/samples/chromium-sample/simple.def
+++ b/samples/chromium-sample/simple.def
@@ -7,7 +7,7 @@ Done processing src/io_thread.cc
 Done processing src/io_thread.h
 Total errors found: 13
 
-src/chrome_content_renderer_client.cc:113:  Include the directory when naming .h files  [build/include_subdir] [4]
+src/chrome_content_renderer_client.cc:113:  Include the directory when naming header files  [build/include_subdir] [4]
 src/chrome_content_renderer_client.cc:1156:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
 src/chrome_content_renderer_client.cc:1161:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
 src/chrome_content_renderer_client.cc:5:  samples/chromium-sample/src/chrome_content_renderer_client.cc should include its header file samples/chromium-sample/src/chrome_content_renderer_client.h  [build/include] [5]

--- a/samples/codelite-sample/simple.def
+++ b/samples/codelite-sample/simple.def
@@ -6,7 +6,7 @@ Done processing src/pptable.h
 Total errors found: 681
 
 src/pptable.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
-src/pptable.cpp:1:  Include the directory when naming .h files  [build/include_subdir] [4]
+src/pptable.cpp:1:  Include the directory when naming header files  [build/include_subdir] [4]
 src/pptable.cpp:6:  { should almost always be at the end of the previous line  [whitespace/braces] [4]
 src/pptable.cpp:7:  Tab found; better to use spaces  [whitespace/tab] [1]
 src/pptable.cpp:8:  Tab found; better to use spaces  [whitespace/tab] [1]

--- a/samples/vlc-sample/simple.def
+++ b/samples/vlc-sample/simple.def
@@ -11,7 +11,7 @@ src/libvlc.c:47:  Found C system header after other header. Should be: libvlc.h,
 src/libvlc.c:48:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:49:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:50:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
-src/libvlc.c:71:  Include the directory when naming .h files  [build/include_subdir] [4]
+src/libvlc.c:71:  Include the directory when naming header files  [build/include_subdir] [4]
 src/libvlc.c:75:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:86:  Extra space before [  [whitespace/braces] [5]
 src/libvlc.c:86:  Extra space after ( in function call  [whitespace/parens] [4]


### PR DESCRIPTION
build/include_subdir should handle arbitrarily header file extensions.

Tests
include "test.hh" // now emits warning with defaults
include "test.h"  // same warning with defaults
include "test.aa" // can emit warning if .aa set as header