### PR TITLE
Allow setting config file name via CLI

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -83,6 +83,7 @@ Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]
                    [--exclude=path]
                    [--extensions=hpp,cpp,...]
                    [--includeorder=default|standardcfirst]
+                   [--config=filename]
                    [--quiet]
                    [--version]
         <file> [file] ...
@@ -228,6 +229,9 @@ Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]
       standardcfirst means to instead use an allow-list of known c headers and
       treat all others as separate group of "other system headers". The C headers
       included are those of the C-standard lib and closely related ones.
+
+    config=filename
+      Search for config files with the specified name instead of CPPLINT.cfg
 
     headers=x,y,...
       The header extensions that cpplint will treat as .h in checks. Values are
@@ -875,6 +879,9 @@ _line_length = 80
 
 # This allows to use different include order rule than default
 _include_order = "default"
+
+# This allows different config files to be used
+_config_filename = "CPPLINT.cfg"
 
 try:
   unicode
@@ -6526,7 +6533,7 @@ def ProcessConfigOverrides(filename):
     if not base_name:
       break  # Reached the root directory.
 
-    cfg_file = os.path.join(abs_path, "CPPLINT.cfg")
+    cfg_file = os.path.join(abs_path, _config_filename)
     abs_filename = abs_path
     if not os.path.isfile(cfg_file):
       continue
@@ -6746,6 +6753,7 @@ def ParseArguments(args):
                                                  'recursive',
                                                  'headers=',
                                                  'includeorder=',
+                                                 'config=',
                                                  'quiet'])
   except getopt.GetoptError:
     PrintUsage('Invalid arguments.')
@@ -6804,6 +6812,9 @@ def ParseArguments(args):
       recursive = True
     elif opt == '--includeorder':
       ProcessIncludeOrderOption(val)
+    elif opt == '--config':
+      global _config_filename
+      _config_filename = val
 
   if not filenames:
     PrintUsage('No files were specified.')

--- a/cpplint.py
+++ b/cpplint.py
@@ -6815,6 +6815,8 @@ def ParseArguments(args):
     elif opt == '--config':
       global _config_filename
       _config_filename = val
+      if os.path.basename(_config_filename) != _config_filename:
+        PrintUsage('Config file name must not include directory components.')
 
   if not filenames:
     PrintUsage('No files were specified.')


### PR DESCRIPTION
This introduces a new command-line option that allows configuration overrides to be read from a file with a name other than `CPPLINT.cfg`.  This can be useful if one wants to have separate "normal" and "noisy" modes, for example:

```console
  cpplint --config=.cpplint <file>
  cpplint --config=.cpplint-noisy <file>
```

It's also nice if you'd prefer a config file named `.cpplint` to a non-dotfile named in ALL CAPS.

---

I have tested this manually, but I haven't looked into adding testcases yet, as that's a bigger job than these changes were.  I'm willing to do that work, but my time is somewhat limited.