### PR TITLE
Files with '.hh' extension are not system headers

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -5012,7 +5012,8 @@ def _ClassifyInclude(fileinfo, include, used_angle_brackets, include_order="defa
             or Search(r'(?:%s)\/.*\.h' % "|".join(C_STANDARD_HEADER_FOLDERS), include))
 
   # Headers with C++ extensions shouldn't be considered C system headers
-  is_system = used_angle_brackets and not os.path.splitext(include)[1] in ['.hpp', '.hxx', '.h++']
+  include_ext = os.path.splitext(include)[1]
+  is_system = used_angle_brackets and not include_ext in ['.hh', '.hpp', '.hxx', '.h++']
 
   if is_system:
     if is_cpp_header:


### PR DESCRIPTION
Support for checking .hh headers by default was added in
https://github.com/cpplint/cpplint/commit/3d8f6f876dd6e3918e5641483298dbc82e65f358.

However, without this change .hh files being included are considered to be C system headers.