### PR TITLE
add --standardstd to imporve issue #194

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.6.1 (2022-06-23)
+-----
+
+* Fix #194: "Why was regex (and other C++11 headers) unapproved?"
+
 1.6.0 (2022-02-19)
 -----
 

--- a/cpplint.py
+++ b/cpplint.py
@@ -67,6 +67,7 @@ _valid_extensions = set([])
 __VERSION__ = '1.6.0'
 
 try:
+  #  -- pylint: disable=used-before-assignment
   xrange          # Python 2
 except NameError:
   #  -- pylint: disable=redefined-builtin
@@ -877,12 +878,14 @@ _line_length = 80
 _include_order = "default"
 
 try:
+  #  -- pylint: disable=used-before-assignment
   unicode
 except NameError:
   #  -- pylint: disable=redefined-builtin
   basestring = unicode = str
 
 try:
+  #  -- pylint: disable=used-before-assignment
   long
 except NameError:
   #  -- pylint: disable=redefined-builtin

--- a/cpplint.py
+++ b/cpplint.py
@@ -64,7 +64,7 @@ import xml.etree.ElementTree
 # if empty, use defaults
 _valid_extensions = set([])
 
-__VERSION__ = '1.6.0'
+__VERSION__ = '1.6.1'
 
 try:
   #  -- pylint: disable=used-before-assignment


### PR DESCRIPTION
There should be many developers who use the standard C++ library to develop their applications. I feel that it is not very reasonable to force use of Google's style to limit the use of the standard C++ library, so I added a flag to skip the standard C++ header file check.

And fix some pylint check problems.