### PR TITLE
Fix for <algorithm> copy - issue #200, #167

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -5936,7 +5936,7 @@ _HEADERS_CONTAINING_TEMPLATES = (
     )
 
 _HEADERS_MAYBE_TEMPLATES = (
-    ('<algorithm>', ('copy', 'max', 'min', 'min_element', 'sort',
+    ('<algorithm>', ('std::copy', 'max', 'min', 'min_element', 'sort',
                      'transform',
                     )),
     ('<utility>', ('forward', 'make_pair', 'move', 'swap')),

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -950,6 +950,17 @@ class CpplintTest(CpplintTestBase):
 
   def testIncludeWhatYouUse(self):
     self.TestIncludeWhatYouUse(
+        'std::filesystem::copy(from, to);',
+        '')
+    self.TestIncludeWhatYouUse(
+        'void copy(from, to);',
+        '')
+    self.TestIncludeWhatYouUse(
+        """
+           std::copy(vec.begin(), vec.end.(), std::back_inserter(dst));
+        """,
+        'Add #include <algorithm> for std::copy  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
         """#include <vector>
            std::vector<int> foo;
         """,


### PR DESCRIPTION
This fixes issues #200 and #167.
In general all algorithm templates should be prefixed with std:: to avoid the same problem.
Unittest that covers this behaviour are included.