### PR TITLE
Add support for NOLINTBEGIN/END

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [BASIC]
 include-naming-hint=yes
-method-rgx=[A-Z_][A-Za-z0-9]{2,49}$|__init__
+method-rgx=[A-Z_][A-Za-z0-9]{2,49}$|__init__|__str__|__contains__
 function-rgx=[A-Z_][A-Za-z0-9]{2,49}$|main
 const-rgx=[a-zA-Z_][A-Za-z0-9_]{2,49}$
 variable-rgx=[a-z_][a-z0-9_]{0,49}$

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,7 @@ A bunch of long-overdue modernizations of the codebase!
 
 * Python 2 is no longer supported. Python 3.7 and 3.12 support was added, courtesy of @jayvdb
    * As a result of all this, setup.py's lint subcommand was removed. Please run the commands directly instead.
+* You can now specify blocks of code that exclude linting with NOLINTBEGIN and NOLINTEND, courtesy of @n3world (https://github.com/cpplint/cpplint/pull/213)
 * NOLINT and NOLINTNEXTLINE comments now support a comma-separated list of categories, courtesy of @n3world (https://github.com/cpplint/cpplint/pull/220)
 * The `--filter` option can now be only applied to a specific file or even a specific line through utilizing colons, e.g. `-filter=-whitespace:foo.h,+whitespace/braces:foo.h:418`. Courtesy of @PhilLab (https://github.com/cpplint/cpplint/pull/171)
 * NOLINT and NOLINTNEXTLINE will now ignore categories known to be from clang-tidy thanks to @xatier (https://github.com/cpplint/cpplint/pull/231)

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -604,6 +604,86 @@ class CpplintTest(CpplintTestBase):
                              ''],
                             error_collector)
     self.assertEquals('', error_collector.Results())
+    # NOLINTBEGIN and silences all warnings after it
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             '// NOLINTBEGIN',
+                             'long a = (int64) 65;'
+                             'long a = 65;',
+                             '//  ./command' + (' -verbose' * 80)],
+                            error_collector)
+    self.assertEquals('', error_collector.Results())
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             '// NOLINTBEGIN(*)',
+                             'long a = (int64) 65;'
+                             'long a = 65;',
+                             '//  ./command' + (' -verbose' * 80)],
+                            error_collector)
+    self.assertEquals('', error_collector.Results())
+    # NOLINTEND will show warnings after that point
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             '// NOLINTBEGIN',
+                             'long a = (int64) 65;'
+                             'long a = 65;',
+                             '// NOLINTEND'
+                             '//  ./command' + (' -verbose' * 80),
+                             ''],
+                            error_collector)
+    self.assertEquals('Lines should be <= 80 characters long  '
+                      '[whitespace/line_length] [2]', error_collector.Results())
+    # NOLINTBEGIN(category) silences category warnings after it
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             '// NOLINTBEGIN(readability/casting,runtime/int)',
+                             'long a = (int64) 65;',
+                             'long a = 65;',
+                             '//  ./command' + (' -verbose' * 80),
+                             ''],
+                            error_collector)
+    self.assertEquals('Lines should be <= 80 characters long  '
+                      '[whitespace/line_length] [2]',
+                      error_collector.Results())
+    # NOLINTEND(category) will generate an error that categories are not supported
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             '// NOLINTBEGIN(readability/casting,runtime/int)',
+                             'long a = (int64) 65;',
+                             'long a = 65;',
+                             '// NOLINTEND(readability/casting)',
+                             ''],
+                            error_collector)
+    self.assertEquals('NOLINT categories not supported in block END: readability/casting  '
+                      '[readability/nolint] [5]',
+                      error_collector.Results())
+    # nested NOLINTBEGIN is not allowed
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             '// NOLINTBEGIN(readability/casting,runtime/int)',
+                             'long a = (int64) 65;',
+                             '// NOLINTBEGIN(runtime/int)',
+                             'long a = 65;',
+                             '// NOLINTEND(*)',
+                             ''],
+                            error_collector)
+    self.assertEquals('NONLINT block already defined on line 2  '
+                      '[readability/nolint] [5]', error_collector.Results())
+    # error if unmatched NOLINTEND
+    self.TestLint(
+        '// NOLINTEND',
+        'Not in a NOLINT block  '
+        '[readability/nolint] [5]')
+    self.TestLint(
+        '// NOLINTEND(*)',
+        'Not in a NOLINT block  '
+        '[readability/nolint] [5]')
 
   # Test Variable Declarations.
   def testVariableDeclarations(self):

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -158,7 +158,7 @@ class CpplintTestBase(unittest.TestCase):
 
   # Perform lint on single line of input and return the error message.
   def PerformSingleLineLint(self, code):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     lines = code.split('\n')
     cpplint.RemoveMultiLineComments('foo.h', lines, error_collector)
     clean_lines = cpplint.CleansedLines(lines)
@@ -176,7 +176,7 @@ class CpplintTestBase(unittest.TestCase):
 
   # Perform lint over multiple lines and return the error message.
   def PerformMultiLineLint(self, code):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     lines = code.split('\n')
     cpplint.RemoveMultiLineComments('foo.h', lines, error_collector)
     lines = cpplint.CleansedLines(lines)
@@ -193,7 +193,7 @@ class CpplintTestBase(unittest.TestCase):
   # Similar to PerformMultiLineLint, but calls CheckLanguage instead of
   # CheckForNonStandardConstructs
   def PerformLanguageRulesCheck(self, file_name, code):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     include_state = cpplint._IncludeState()
     nesting_state = cpplint.NestingState()
     lines = code.split('\n')
@@ -221,7 +221,7 @@ class CpplintTestBase(unittest.TestCase):
       The accumulated errors.
     """
     file_name = 'foo.cc'
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     function_state = cpplint._FunctionState()
     lines = code.split('\n')
     cpplint.RemoveMultiLineComments(file_name, lines, error_collector)
@@ -233,7 +233,7 @@ class CpplintTestBase(unittest.TestCase):
 
   def PerformIncludeWhatYouUse(self, code, filename='foo.h', io=codecs):
     # First, build up the include state.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     include_state = cpplint._IncludeState()
     nesting_state = cpplint.NestingState()
     lines = code.split('\n')
@@ -277,7 +277,7 @@ class CpplintTestBase(unittest.TestCase):
       self.doTestBlankLinesCheck(lines, start_errors, end_errors, extension)
 
   def doTestBlankLinesCheck(self, lines, start_errors, end_errors, extension):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.' + extension, extension, lines, error_collector)
     self.assertEqual(
         start_errors,
@@ -294,7 +294,7 @@ class CpplintTestBase(unittest.TestCase):
 class CpplintTest(CpplintTestBase):
 
   def GetNamespaceResults(self, lines):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.RemoveMultiLineComments('foo.h', lines, error_collector)
     lines = cpplint.CleansedLines(lines)
     nesting_state = cpplint.NestingState()
@@ -514,7 +514,7 @@ class CpplintTest(CpplintTestBase):
         'Use int16/int64/etc, rather than the C type long'
         '  [runtime/int] [4]')
     # NOLINTNEXTLINE silences warning for the next line instead of current line
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTNEXTLINE(whitespace/line_length)',
@@ -523,7 +523,7 @@ class CpplintTest(CpplintTestBase):
                             error_collector)
     self.assertEqual('', error_collector.Results())
     # NOLINTNEXTLINE multiple categories silences warning for the next line instead of current line
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTNEXTLINE(runtime/int,readability/casting)',
@@ -532,7 +532,7 @@ class CpplintTest(CpplintTestBase):
                             error_collector)
     self.assertEqual('', error_collector.Results())
     # LINT_C_FILE silences cast warnings for entire file.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.h', 'h',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINT(build/header_guard)',
@@ -566,7 +566,7 @@ class CpplintTest(CpplintTestBase):
                      'vim: se filetype=c :',
                      'vim: se sw=8 filetype=c :',
                      'vim: se sw=8 filetype=c ts=8 :']:
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData('test.h', 'h',
                               ['// Copyright 2014 Your Company.',
                                '// NOLINT(build/header_guard)',
@@ -578,7 +578,7 @@ class CpplintTest(CpplintTestBase):
                               error_collector)
       self.assertEqual('', error_collector.Results())
     # LINT_KERNEL_FILE silences whitespace/tab warnings for entire file.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.h', 'h',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINT(build/header_guard)',
@@ -590,7 +590,7 @@ class CpplintTest(CpplintTestBase):
                             error_collector)
     self.assertEqual('', error_collector.Results())
     # NOLINT, NOLINTNEXTLINE silences the readability/braces warning for "};".
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              'for (int i = 0; i != 100; ++i) {',
@@ -605,7 +605,7 @@ class CpplintTest(CpplintTestBase):
                             error_collector)
     self.assertEqual('', error_collector.Results())
     # NOLINTBEGIN and silences all warnings after it
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTBEGIN',
@@ -614,7 +614,7 @@ class CpplintTest(CpplintTestBase):
                              '//  ./command' + (' -verbose' * 80)],
                             error_collector)
     self.assertEqual('', error_collector.Results())
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTBEGIN(*)',
@@ -624,7 +624,7 @@ class CpplintTest(CpplintTestBase):
                             error_collector)
     self.assertEqual('', error_collector.Results())
     # NOLINTEND will show warnings after that point
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTBEGIN',
@@ -637,7 +637,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEqual('Lines should be <= 80 characters long  '
                       '[whitespace/line_length] [2]', error_collector.Results())
     # NOLINTBEGIN(category) silences category warnings after it
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTBEGIN(readability/casting,runtime/int)',
@@ -651,7 +651,7 @@ class CpplintTest(CpplintTestBase):
                       '[whitespace/line_length] [2]',
                       error_collector.Results())
     # NOLINTEND(category) will generate an error that categories are not supported
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTBEGIN(readability/casting,runtime/int)',
@@ -664,7 +664,7 @@ class CpplintTest(CpplintTestBase):
                       '[readability/nolint] [5]',
                       error_collector.Results())
     # nested NOLINTBEGIN is not allowed
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTBEGIN(readability/casting,runtime/int)',
@@ -677,7 +677,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEqual('NONLINT block already defined on line 2  '
                       '[readability/nolint] [5]', error_collector.Results())
     # error if NOLINGBEGIN is not ended
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTBEGIN(readability/casting,runtime/int)',
@@ -942,7 +942,7 @@ class CpplintTest(CpplintTestBase):
     self.TestLint('std::function< int(bool) >', '')
     self.TestLint('mfunction<int(bool)>', '')
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         'test.cc', 'cc',
         ['// Copyright 2014 Your Company. All Rights Reserved.',
@@ -981,7 +981,7 @@ class CpplintTest(CpplintTestBase):
         'MOCK_CONST_METHOD1(method, SomeType(int));',
         '')
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('mock.cc', 'cc',
                             ['MOCK_METHOD1(method1,',
                              '             bool(int));',
@@ -1478,7 +1478,7 @@ class CpplintTest(CpplintTestBase):
     for extension in ['c', 'cc', 'cpp', 'cxx', 'c++', 'cu']:
       file_path = 'mydir/foo.' + extension
 
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData(file_path, extension,
                               ['const char* str = "This is a\\',
                                ' multiline string.";'],
@@ -1829,7 +1829,7 @@ class CpplintTest(CpplintTestBase):
           };""",
           '')
       # Special case for variadic arguments
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData('foo.cc', 'cc',
           ['class Foo {',
           '  template<typename... Args>',
@@ -1839,7 +1839,7 @@ class CpplintTest(CpplintTestBase):
       self.assertEqual(0, error_collector.ResultList().count(
         'Constructors that require multiple arguments should not be marked '
         'explicit.  [runtime/explicit] [0]'))
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData('foo.cc', 'cc',
           ['class Foo {',
           '  template<typename... Args>',
@@ -1849,7 +1849,7 @@ class CpplintTest(CpplintTestBase):
       self.assertEqual(0, error_collector.ResultList().count(
         'Constructors that require multiple arguments should not be marked '
         'explicit.  [runtime/explicit] [0]'))
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData('foo.cc', 'cc',
           ['class Foo {',
           '  template<typename... Args>',
@@ -1859,7 +1859,7 @@ class CpplintTest(CpplintTestBase):
       self.assertEqual(1, error_collector.ResultList().count(
         'Constructors callable with one argument should be marked explicit.'
         '  [runtime/explicit] [5]'))
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData('foo.cc', 'cc',
           ['class Foo {',
           '  template<typename... Args>',
@@ -1870,7 +1870,7 @@ class CpplintTest(CpplintTestBase):
         'Constructors callable with one argument should be marked explicit.'
         '  [runtime/explicit] [5]'))
       # Anything goes inside an assembly block
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData('foo.cc', 'cc',
                               ['void Func() {',
                                '  __asm__ (',
@@ -1980,7 +1980,7 @@ class CpplintTest(CpplintTestBase):
       self.TestLint('virtual int F() %s;' % virt_specifier, error_message)
       self.TestLint('virtual int F() %s {' % virt_specifier, error_message)
 
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData(
           'foo.cc', 'cc',
           ['// Copyright 2014 Your Company.',
@@ -2005,7 +2005,7 @@ class CpplintTest(CpplintTestBase):
     self.TestLint('int F() final override;', error_message)
     self.TestLint('int F() final override {}', error_message)
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         'foo.cc', 'cc',
         ['// Copyright 2014 Your Company.',
@@ -2179,7 +2179,7 @@ class CpplintTest(CpplintTestBase):
     for macro_name in (
         'DISALLOW_COPY_AND_ASSIGN',
         'DISALLOW_IMPLICIT_CONSTRUCTORS'):
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData(
           'foo.cc', 'cc',
           ['// Copyright 2014 Your Company.',
@@ -2195,7 +2195,7 @@ class CpplintTest(CpplintTestBase):
           '  [readability/constructors] [3]',
           error_collector.Results())
 
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData(
           'foo.cc', 'cc',
           ['// Copyright 2014 Your Company.',
@@ -2214,7 +2214,7 @@ class CpplintTest(CpplintTestBase):
           '  [readability/constructors] [3]',
           error_collector.Results())
 
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData(
           'foo.cc', 'cc',
           ['// Copyright 2014 Your Company.',
@@ -2547,7 +2547,7 @@ class CpplintTest(CpplintTestBase):
 
     # Don't warn on out-of-line method definitions.
     self.TestLint('void NS::Func(X& x) {', '')
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         'foo.cc', 'cc',
         ['// Copyright 2014 Your Company. All Rights Reserved.',
@@ -2561,7 +2561,7 @@ class CpplintTest(CpplintTestBase):
 
     # Other potential false positives.  These need full parser
     # state to reproduce as opposed to just TestLint.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         'foo.cc', 'cc',
         ['// Copyright 2014 Your Company. All Rights Reserved.',
@@ -2604,7 +2604,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEqual('', error_collector.Results())
 
     # Multi-line references
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         'foo.cc', 'cc',
         ['// Copyright 2014 Your Company. All Rights Reserved.',
@@ -2630,7 +2630,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.Results())
 
     # A peculiar false positive due to bad template argument parsing
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         'foo.cc', 'cc',
         ['// Copyright 2014 Your Company. All Rights Reserved.',
@@ -2650,7 +2650,7 @@ class CpplintTest(CpplintTestBase):
                   '{ should almost always be at the end of the previous line'
                   '  [whitespace/braces] [4]')
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['int function()',
                              '{',  # warning here
@@ -3161,7 +3161,7 @@ class CpplintTest(CpplintTestBase):
                   '}\n', '')
 
     # Check multiline cases.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              'string Class',
@@ -3312,7 +3312,7 @@ class CpplintTest(CpplintTestBase):
   # 1' line was also causing the issue.
   def testLinePrecededByEmptyOrCommentLines(self):
     def DoTest(self, lines):
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData('foo.cc', 'cc', lines, error_collector)
       # The warning appears only once.
       self.assertEqual(
@@ -3335,7 +3335,7 @@ class CpplintTest(CpplintTestBase):
 
   def testNewlineAtEOF(self):
     def DoTest(self, data, is_missing_eof):
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData('foo.cc', 'cc', data.split('\n'),
                               error_collector)
       # The warning appears only once.
@@ -3350,7 +3350,7 @@ class CpplintTest(CpplintTestBase):
 
   def testInvalidUtf8(self):
     def DoTest(self, raw_bytes, has_invalid_utf8):
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       if sys.version_info < (3,):
           unidata = unicode(raw_bytes, 'utf8', 'replace').split('\n')
       else:
@@ -3376,7 +3376,7 @@ class CpplintTest(CpplintTestBase):
 
   def testBadCharacters(self):
     # Test for NUL bytes only
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('nul.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '\0', ''], error_collector)
@@ -3386,7 +3386,7 @@ class CpplintTest(CpplintTestBase):
 
     # Make sure both NUL bytes and UTF-8 are caught if they appear on
     # the same line.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     raw_bytes = codecs_latin_encode('\xe9x\0')
     if sys.version_info < (3,):
       unidata = unicode(raw_bytes, 'utf8', 'replace')
@@ -3405,11 +3405,11 @@ class CpplintTest(CpplintTestBase):
          'Line contains NUL byte.  [readability/nul] [5]'])
 
   def testIsBlankLine(self):
-    self.assert_(cpplint.IsBlankLine(''))
-    self.assert_(cpplint.IsBlankLine(' '))
-    self.assert_(cpplint.IsBlankLine(' \t\r\n'))
-    self.assert_(not cpplint.IsBlankLine('int a;'))
-    self.assert_(not cpplint.IsBlankLine('{'))
+    self.assertTrue(cpplint.IsBlankLine(''))
+    self.assertTrue(cpplint.IsBlankLine(' '))
+    self.assertTrue(cpplint.IsBlankLine(' \t\r\n'))
+    self.assertTrue(not cpplint.IsBlankLine('int a;'))
+    self.assertTrue(not cpplint.IsBlankLine('{'))
 
   def testBlankLinesCheck(self):
     self.TestBlankLinesCheck(['{\n', '\n', '\n', '}\n'], 1, 1)
@@ -3428,7 +3428,7 @@ class CpplintTest(CpplintTestBase):
         ['int x(\n', '   int a) {\n', '\n', 'return 0;\n', '}'], 1, 0)
 
   def testAllowBlankLineBeforeClosingNamespace(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['namespace {',
                              '',
@@ -3453,7 +3453,7 @@ class CpplintTest(CpplintTestBase):
         '  [whitespace/blank_line] [3]'))
 
   def testAllowBlankLineBeforeIfElseChain(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['if (hoge) {',
                              '',  # No warning
@@ -3470,7 +3470,7 @@ class CpplintTest(CpplintTestBase):
         '  [whitespace/blank_line] [3]'))
 
   def testAllowBlankLineAfterExtern(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['extern "C" {',
                              '',
@@ -3486,7 +3486,7 @@ class CpplintTest(CpplintTestBase):
         '  [whitespace/blank_line] [3]'))
 
   def testBlankLineBeforeSectionKeyword(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['class A {',
                              ' public:',
@@ -3522,7 +3522,7 @@ class CpplintTest(CpplintTestBase):
         '  [whitespace/blank_line] [3]'))
 
   def testNoBlankLineAfterSectionKeyword(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['class A {',
                              ' public:',
@@ -3546,7 +3546,7 @@ class CpplintTest(CpplintTestBase):
         '  [whitespace/blank_line] [3]'))
 
   def testAllowBlankLinesInRawStrings(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              'static const char *kData[] = {R"(',
@@ -3559,7 +3559,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEqual('', error_collector.Results())
 
   def testElseOnSameLineAsClosingBraces(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['if (hoge) {',
                              '}',
@@ -3573,7 +3573,7 @@ class CpplintTest(CpplintTestBase):
         'An else should appear on the same line as the preceding }'
         '  [whitespace/newline] [4]'))
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['if (hoge) {',
                              '',
@@ -3587,7 +3587,7 @@ class CpplintTest(CpplintTestBase):
         'An else should appear on the same line as the preceding }'
         '  [whitespace/newline] [4]'))
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['if (hoge) {',
                              '',
@@ -3599,7 +3599,7 @@ class CpplintTest(CpplintTestBase):
         '  [whitespace/newline] [4]'))
 
   def testMultipleStatementsOnSameLine(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['for (int i = 0; i < 1; i++) {}',
                              'switch (x) {',
@@ -3618,7 +3618,7 @@ class CpplintTest(CpplintTestBase):
     cpplint._cpplint_state.verbose_level = old_verbose_level
 
   def testLambdasOnSameLine(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     old_verbose_level = cpplint._cpplint_state.verbose_level
     cpplint._cpplint_state.verbose_level = 0
     cpplint.ProcessFileData('foo.cc', 'cc',
@@ -3629,7 +3629,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEqual(0, error_collector.Results().count(
         'More than one command on the same line  [whitespace/newline] [0]'))
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     old_verbose_level = cpplint._cpplint_state.verbose_level
     cpplint._cpplint_state.verbose_level = 0
     cpplint.ProcessFileData('foo.cc', 'cc',
@@ -3641,7 +3641,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEqual(0, error_collector.Results().count(
         'More than one command on the same line  [whitespace/newline] [0]'))
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     old_verbose_level = cpplint._cpplint_state.verbose_level
     cpplint._cpplint_state.verbose_level = 0
     cpplint.ProcessFileData('foo.cc', 'cc',
@@ -3653,7 +3653,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEqual(0, error_collector.Results().count(
         'More than one command on the same line  [whitespace/newline] [0]'))
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     old_verbose_level = cpplint._cpplint_state.verbose_level
     cpplint._cpplint_state.verbose_level = 0
     cpplint.ProcessFileData('foo.cc', 'cc',
@@ -3666,7 +3666,7 @@ class CpplintTest(CpplintTestBase):
         'More than one command on the same line  [whitespace/newline] [0]'))
 
   def testEndOfNamespaceComments(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('foo.cc', 'cc',
                             ['namespace {',
                              '',
@@ -4482,7 +4482,7 @@ class CpplintTest(CpplintTestBase):
       cpplint._DEFAULT_FILTERS = default_filters
 
   def testDuplicateHeader(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('path/self.cc', 'cc',
                             ['// Copyright 2014 Your Company. All Rights Reserved.',
                              '#include "path/self.h"',
@@ -4586,7 +4586,7 @@ class CpplintTest(CpplintTestBase):
 
   def GetBuildHeaderGuardPreprocessorSymbol(self, file_path):
     # Figure out the expected header guard by processing an empty file.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h', [], error_collector)
     for error in error_collector.ResultList():
       matched = re.search(
@@ -4602,7 +4602,7 @@ class CpplintTest(CpplintTestBase):
     self.assertTrue(re.search('MYDIR_FOO_H_$', expected_guard))
 
     # No guard at all: expect one error.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h', [], error_collector)
     self.assertEqual(
         1,
@@ -4612,7 +4612,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
     # No header guard, but the error is suppressed.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['// Copyright 2014 Your Company.',
                              '// NOLINT(build/header_guard)', ''],
@@ -4620,7 +4620,7 @@ class CpplintTest(CpplintTestBase):
     self.assertEqual([], error_collector.ResultList())
 
     # Wrong guard
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef FOO_H', '#define FOO_H'], error_collector)
     self.assertEqual(
@@ -4631,7 +4631,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
     # No define
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef %s' % expected_guard], error_collector)
     self.assertEqual(
@@ -4642,7 +4642,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
     # Mismatched define
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef %s' % expected_guard,
                              '#define FOO_H'],
@@ -4655,7 +4655,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
     # No endif
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef %s' % expected_guard,
                              '#define %s' % expected_guard,
@@ -4669,7 +4669,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
     # Commentless endif
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef %s' % expected_guard,
                              '#define %s' % expected_guard,
@@ -4683,7 +4683,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
     # Commentless endif for old-style guard
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef %s_' % expected_guard,
                              '#define %s_' % expected_guard,
@@ -4697,7 +4697,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
     # No header guard errors
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef %s' % expected_guard,
                              '#define %s' % expected_guard,
@@ -4708,7 +4708,7 @@ class CpplintTest(CpplintTestBase):
         self.fail('Unexpected error: %s' % line)
 
     # No header guard errors for old-style guard
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef %s_' % expected_guard,
                              '#define %s_' % expected_guard,
@@ -4722,7 +4722,7 @@ class CpplintTest(CpplintTestBase):
     try:
       cpplint._cpplint_state.verbose_level = 0
       # Warn on old-style guard if verbosity is 0.
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData(file_path, 'h',
                               ['#ifndef %s_' % expected_guard,
                                '#define %s_' % expected_guard,
@@ -4738,7 +4738,7 @@ class CpplintTest(CpplintTestBase):
       cpplint._cpplint_state.verbose_level = old_verbose_level
 
     # Completely incorrect header guard
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef FOO',
                              '#define FOO',
@@ -4758,7 +4758,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
     # incorrect header guard with nolint
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef FOO  // NOLINT',
                              '#define FOO',
@@ -4779,7 +4779,7 @@ class CpplintTest(CpplintTestBase):
 
     # Special case for flymake
     for test_file in ['mydir/foo_flymake.h', 'mydir/.flymake/foo.h']:
-      error_collector = ErrorCollector(self.assert_)
+      error_collector = ErrorCollector(self.assertTrue)
       cpplint.ProcessFileData(test_file, 'h',
                               ['// Copyright 2014 Your Company.', ''],
                               error_collector)
@@ -4793,7 +4793,7 @@ class CpplintTest(CpplintTestBase):
     # Cuda guard
     file_path = 'mydir/foo.cuh'
     expected_guard = self.GetBuildHeaderGuardPreprocessorSymbol(file_path)
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'cuh',
                             ['#ifndef FOO',
                              '#define FOO',
@@ -4813,7 +4813,7 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList())
 
   def testPragmaOnce(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData('mydir/foo.h', 'h',
         ['// Copyright 2014 Your Company.', '#pragma once', ''],
         error_collector)
@@ -5093,7 +5093,7 @@ class CpplintTest(CpplintTestBase):
     self.TestLanguageRulesCheck('foo.h', code, '')
 
   def testBuildPrintfFormat(self):
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         'foo.cc', 'cc',
         [r'printf("\%%d", value);',
@@ -5107,7 +5107,7 @@ class CpplintTest(CpplintTestBase):
             '%, [, (, and { are undefined character escapes.  Unescape them.'
             '  [build/printf_format] [3]'))
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         'foo.cc', 'cc',
         ['// Copyright 2014 Your Company.',
@@ -5226,13 +5226,13 @@ class CpplintTest(CpplintTestBase):
     file_path = 'mydir/googleclient/foo.cc'
 
     # There should be a copyright message in the first 10 lines
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'cc', [], error_collector)
     self.assertEqual(
         1,
         error_collector.ResultList().count(legal_copyright_message))
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         file_path, 'cc',
         ['' for unused_i in range(10)] + [copyright_line],
@@ -5242,13 +5242,13 @@ class CpplintTest(CpplintTestBase):
         error_collector.ResultList().count(legal_copyright_message))
 
     # Test that warning isn't issued if Copyright line appears early enough.
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(file_path, 'cc', [copyright_line], error_collector)
     for message in error_collector.ResultList():
       if message.find('legal/copyright') != -1:
         self.fail('Unexpected error: %s' % message)
 
-    error_collector = ErrorCollector(self.assert_)
+    error_collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(
         file_path, 'cc',
         ['' for unused_i in range(9)] + [copyright_line],
@@ -5284,14 +5284,14 @@ class Cxx11Test(CpplintTestBase):
     lines.append('')
 
     # Process the file and check resulting error count.
-    collector = ErrorCollector(self.assert_)
+    collector = ErrorCollector(self.assertTrue)
     cpplint.ProcessFileData(filename, extension, lines, collector)
     error_list = collector.ResultList()
     self.assertEqual(count, len(error_list), error_list)
 
   def TestCxx11Feature(self, code, expected_error):
     lines = code.split('\n')
-    collector = ErrorCollector(self.assert_)
+    collector = ErrorCollector(self.assertTrue)
     cpplint.RemoveMultiLineComments('foo.h', lines, collector)
     clean_lines = cpplint.CleansedLines(lines)
     cpplint.FlagCxx11Features('foo.cc', clean_lines, 0, collector)
@@ -5349,7 +5349,7 @@ class Cxx14Test(CpplintTestBase):
 
   def TestCxx14Feature(self, code, expected_error):
     lines = code.split('\n')
-    collector = ErrorCollector(self.assert_)
+    collector = ErrorCollector(self.assertTrue)
     cpplint.RemoveMultiLineComments('foo.h', lines, collector)
     clean_lines = cpplint.CleansedLines(lines)
     cpplint.FlagCxx14Features('foo.cc', clean_lines, 0, collector)
@@ -6172,7 +6172,7 @@ class NestingStateTest(unittest.TestCase):
 
   def setUp(self):
     self.nesting_state = cpplint.NestingState()
-    self.error_collector = ErrorCollector(self.assert_)
+    self.error_collector = ErrorCollector(self.assertTrue)
 
   def UpdateWithLines(self, lines):
     clean_lines = cpplint.CleansedLines(lines)

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -253,10 +253,10 @@ class CpplintTestBase(unittest.TestCase):
 
   # Perform lint and compare the error message with "expected_message".
   def TestLint(self, code, expected_message):
-    self.assertEquals(expected_message, self.PerformSingleLineLint(code))
+    self.assertEqual(expected_message, self.PerformSingleLineLint(code))
 
   def TestMultiLineLint(self, code, expected_message):
-    self.assertEquals(expected_message, self.PerformMultiLineLint(code))
+    self.assertEqual(expected_message, self.PerformMultiLineLint(code))
 
   def TestMultiLineLintRE(self, code, expected_message_re):
     message = self.PerformMultiLineLint(code)
@@ -265,12 +265,12 @@ class CpplintTestBase(unittest.TestCase):
                 expected_message_re + '"')
 
   def TestLanguageRulesCheck(self, file_name, code, expected_message):
-    self.assertEquals(expected_message,
-                      self.PerformLanguageRulesCheck(file_name, code))
+    self.assertEqual(expected_message,
+                     self.PerformLanguageRulesCheck(file_name, code))
 
   def TestIncludeWhatYouUse(self, code, expected_message):
-    self.assertEquals(expected_message,
-                      self.PerformIncludeWhatYouUse(code))
+    self.assertEqual(expected_message,
+                     self.PerformIncludeWhatYouUse(code))
 
   def TestBlankLinesCheck(self, lines, start_errors, end_errors):
     for extension in ['c', 'cc', 'cpp', 'cxx', 'c++', 'cu']:
@@ -279,12 +279,12 @@ class CpplintTestBase(unittest.TestCase):
   def doTestBlankLinesCheck(self, lines, start_errors, end_errors, extension):
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('foo.' + extension, extension, lines, error_collector)
-    self.assertEquals(
+    self.assertEqual(
         start_errors,
         error_collector.Results().count(
             'Redundant blank line at the start of a code block '
             'should be deleted.  [whitespace/blank_line] [2]'))
-    self.assertEquals(
+    self.assertEqual(
         end_errors,
         error_collector.Results().count(
             'Redundant blank line at the end of a code block '
@@ -311,8 +311,8 @@ class CpplintTest(CpplintTestBase):
              '}  // namespace Test']
 
     results = self.GetNamespaceResults(lines)
-    self.assertEquals(results, 'Do not indent within a namespace '
-                      ' [runtime/indentation_namespace] [4]')
+    self.assertEqual(results, 'Do not indent within a namespace '
+                     ' [runtime/indentation_namespace] [4]')
 
   def testNameSpaceIndentationForClass(self):
     lines = ['namespace Test {',
@@ -322,7 +322,7 @@ class CpplintTest(CpplintTestBase):
              '}  // namespace Test']
 
     results = self.GetNamespaceResults(lines)
-    self.assertEquals(results, 'Do not indent within a namespace '
+    self.assertEqual(results, 'Do not indent within a namespace '
                       ' [runtime/indentation_namespace] [4]')
 
   def testNameSpaceIndentationNoError(self):
@@ -331,7 +331,7 @@ class CpplintTest(CpplintTestBase):
              '}  // namespace Test']
 
     results = self.GetNamespaceResults(lines)
-    self.assertEquals(results, '')
+    self.assertEqual(results, '')
 
   def testWhitespaceBeforeNamespace(self):
     lines = ['  namespace Test {',
@@ -339,7 +339,7 @@ class CpplintTest(CpplintTestBase):
              '  }  // namespace Test']
 
     results = self.GetNamespaceResults(lines)
-    self.assertEquals(results, '')
+    self.assertEqual(results, '')
 
   def testFalsePositivesNoError(self):
     lines = ['namespace Test {',
@@ -350,58 +350,58 @@ class CpplintTest(CpplintTestBase):
              '}  // namespace Test']
 
     results = self.GetNamespaceResults(lines)
-    self.assertEquals(results, '')
+    self.assertEqual(results, '')
 
   # Test get line width.
   def testGetLineWidth(self):
-    self.assertEquals(0, cpplint.GetLineWidth(''))
-    self.assertEquals(10, cpplint.GetLineWidth(unicode('x') * 10))
-    self.assertEquals(16, cpplint.GetLineWidth(unicode_escape_decode('\u90fd|\u9053|\u5e9c|\u770c|\u652f\u5e81')))
-    self.assertEquals(16, cpplint.GetLineWidth(u'都|道|府|県|支庁'))
-    self.assertEquals(5 + 13 + 9, cpplint.GetLineWidth(
+    self.assertEqual(0, cpplint.GetLineWidth(''))
+    self.assertEqual(10, cpplint.GetLineWidth(unicode('x') * 10))
+    self.assertEqual(16, cpplint.GetLineWidth(unicode_escape_decode('\u90fd|\u9053|\u5e9c|\u770c|\u652f\u5e81')))
+    self.assertEqual(16, cpplint.GetLineWidth(u'都|道|府|県|支庁'))
+    self.assertEqual(5 + 13 + 9, cpplint.GetLineWidth(
         u'd𝐱/dt' + u'f : t ⨯ 𝐱 → ℝ' + u't ⨯ 𝐱 → ℝ'))
 
   def testGetTextInside(self):
-    self.assertEquals('', cpplint._GetTextInside('fun()', r'fun\('))
-    self.assertEquals('x, y', cpplint._GetTextInside('f(x, y)', r'f\('))
-    self.assertEquals('a(), b(c())', cpplint._GetTextInside(
+    self.assertEqual('', cpplint._GetTextInside('fun()', r'fun\('))
+    self.assertEqual('x, y', cpplint._GetTextInside('f(x, y)', r'f\('))
+    self.assertEqual('a(), b(c())', cpplint._GetTextInside(
         'printf(a(), b(c()))', r'printf\('))
-    self.assertEquals('x, y{}', cpplint._GetTextInside('f[x, y{}]', r'f\['))
-    self.assertEquals(None, cpplint._GetTextInside('f[a, b(}]', r'f\['))
-    self.assertEquals(None, cpplint._GetTextInside('f[x, y]', r'f\('))
-    self.assertEquals('y, h(z, (a + b))', cpplint._GetTextInside(
+    self.assertEqual('x, y{}', cpplint._GetTextInside('f[x, y{}]', r'f\['))
+    self.assertEqual(None, cpplint._GetTextInside('f[a, b(}]', r'f\['))
+    self.assertEqual(None, cpplint._GetTextInside('f[x, y]', r'f\('))
+    self.assertEqual('y, h(z, (a + b))', cpplint._GetTextInside(
         'f(x, g(y, h(z, (a + b))))', r'g\('))
-    self.assertEquals('f(f(x))', cpplint._GetTextInside('f(f(f(x)))', r'f\('))
+    self.assertEqual('f(f(x))', cpplint._GetTextInside('f(f(f(x)))', r'f\('))
     # Supports multiple lines.
-    self.assertEquals('\n  return loop(x);\n',
+    self.assertEqual('\n  return loop(x);\n',
                       cpplint._GetTextInside(
                           'int loop(int x) {\n  return loop(x);\n}\n', r'\{'))
     # '^' matches the beginning of each line.
-    self.assertEquals('x, y',
-                      cpplint._GetTextInside(
-                          '#include "inl.h"  // skip #define\n'
-                          '#define A2(x, y) a_inl_(x, y, __LINE__)\n'
-                          '#define A(x) a_inl_(x, "", __LINE__)\n',
-                          r'^\s*#define\s*\w+\('))
+    self.assertEqual('x, y',
+                     cpplint._GetTextInside(
+                         '#include "inl.h"  // skip #define\n'
+                         '#define A2(x, y) a_inl_(x, y, __LINE__)\n'
+                         '#define A(x) a_inl_(x, "", __LINE__)\n',
+                         r'^\s*#define\s*\w+\('))
 
   def testFindNextMultiLineCommentStart(self):
-    self.assertEquals(1, cpplint.FindNextMultiLineCommentStart([''], 0))
+    self.assertEqual(1, cpplint.FindNextMultiLineCommentStart([''], 0))
 
     lines = ['a', 'b', '/* c']
-    self.assertEquals(2, cpplint.FindNextMultiLineCommentStart(lines, 0))
+    self.assertEqual(2, cpplint.FindNextMultiLineCommentStart(lines, 0))
 
     lines = ['char a[] = "/*";']  # not recognized as comment.
-    self.assertEquals(1, cpplint.FindNextMultiLineCommentStart(lines, 0))
+    self.assertEqual(1, cpplint.FindNextMultiLineCommentStart(lines, 0))
 
   def testFindNextMultiLineCommentEnd(self):
-    self.assertEquals(1, cpplint.FindNextMultiLineCommentEnd([''], 0))
+    self.assertEqual(1, cpplint.FindNextMultiLineCommentEnd([''], 0))
     lines = ['a', 'b', ' c */']
-    self.assertEquals(2, cpplint.FindNextMultiLineCommentEnd(lines, 0))
+    self.assertEqual(2, cpplint.FindNextMultiLineCommentEnd(lines, 0))
 
   def testRemoveMultiLineCommentsFromRange(self):
     lines = ['a', '  /* comment ', ' * still comment', ' comment */   ', 'b']
     cpplint.RemoveMultiLineCommentsFromRange(lines, 1, 4)
-    self.assertEquals(['a', '/**/', '/**/', '/**/', 'b'], lines)
+    self.assertEqual(['a', '/**/', '/**/', '/**/', 'b'], lines)
 
   def testSpacesAtEndOfLine(self):
     self.TestLint(
@@ -521,7 +521,7 @@ class CpplintTest(CpplintTestBase):
                              '//  ./command' + (' -verbose' * 80),
                              ''],
                             error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
     # NOLINTNEXTLINE multiple categories silences warning for the next line instead of current line
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('test.cc', 'cc',
@@ -530,7 +530,7 @@ class CpplintTest(CpplintTestBase):
                              'long a = (int64) 65;',
                              ''],
                             error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
     # LINT_C_FILE silences cast warnings for entire file.
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('test.h', 'h',
@@ -540,7 +540,7 @@ class CpplintTest(CpplintTestBase):
                              '//  LINT_C_FILE',
                              ''],
                             error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
     # Vim modes silence cast warnings for entire file.
     for modeline in ['vi:filetype=c',
                      'vi:sw=8 filetype=c',
@@ -576,7 +576,7 @@ class CpplintTest(CpplintTestBase):
                                '*/',
                                ''],
                               error_collector)
-      self.assertEquals('', error_collector.Results())
+      self.assertEqual('', error_collector.Results())
     # LINT_KERNEL_FILE silences whitespace/tab warnings for entire file.
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('test.h', 'h',
@@ -588,7 +588,7 @@ class CpplintTest(CpplintTestBase):
                              '//  LINT_KERNEL_FILE',
                              ''],
                             error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
     # NOLINT, NOLINTNEXTLINE silences the readability/braces warning for "};".
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('test.cc', 'cc',
@@ -603,7 +603,7 @@ class CpplintTest(CpplintTestBase):
                              '//  LINT_KERNEL_FILE',
                              ''],
                             error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
     # NOLINTBEGIN and silences all warnings after it
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('test.cc', 'cc',
@@ -613,7 +613,7 @@ class CpplintTest(CpplintTestBase):
                              'long a = 65;',
                              '//  ./command' + (' -verbose' * 80)],
                             error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('test.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
@@ -622,7 +622,7 @@ class CpplintTest(CpplintTestBase):
                              'long a = 65;',
                              '//  ./command' + (' -verbose' * 80)],
                             error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
     # NOLINTEND will show warnings after that point
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('test.cc', 'cc',
@@ -630,11 +630,11 @@ class CpplintTest(CpplintTestBase):
                              '// NOLINTBEGIN',
                              'long a = (int64) 65;'
                              'long a = 65;',
-                             '// NOLINTEND'
+                             '// NOLINTEND',
                              '//  ./command' + (' -verbose' * 80),
                              ''],
                             error_collector)
-    self.assertEquals('Lines should be <= 80 characters long  '
+    self.assertEqual('Lines should be <= 80 characters long  '
                       '[whitespace/line_length] [2]', error_collector.Results())
     # NOLINTBEGIN(category) silences category warnings after it
     error_collector = ErrorCollector(self.assert_)
@@ -644,9 +644,10 @@ class CpplintTest(CpplintTestBase):
                              'long a = (int64) 65;',
                              'long a = 65;',
                              '//  ./command' + (' -verbose' * 80),
+                             '// NOLINTEND',
                              ''],
                             error_collector)
-    self.assertEquals('Lines should be <= 80 characters long  '
+    self.assertEqual('Lines should be <= 80 characters long  '
                       '[whitespace/line_length] [2]',
                       error_collector.Results())
     # NOLINTEND(category) will generate an error that categories are not supported
@@ -659,7 +660,7 @@ class CpplintTest(CpplintTestBase):
                              '// NOLINTEND(readability/casting)',
                              ''],
                             error_collector)
-    self.assertEquals('NOLINT categories not supported in block END: readability/casting  '
+    self.assertEqual('NOLINT categories not supported in block END: readability/casting  '
                       '[readability/nolint] [5]',
                       error_collector.Results())
     # nested NOLINTBEGIN is not allowed
@@ -949,7 +950,7 @@ class CpplintTest(CpplintTestBase):
          '    bool(int)> F;',
          ''],
         error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
 
     # Return types for function pointers
     self.TestLint('typedef bool(FunctionPointer)();', '')
@@ -993,13 +994,13 @@ class CpplintTest(CpplintTestBase):
                              'MOCK_METHOD1(method4, int(bool));',
                              'const int kConstant = int(42);'],  # true positive
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         0,
         error_collector.Results().count(
             ('Using deprecated casting style.  '
              'Use static_cast<bool>(...) instead  '
              '[readability/casting] [4]')))
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.Results().count(
             ('Using deprecated casting style.  '
@@ -1045,11 +1046,11 @@ class CpplintTest(CpplintTestBase):
   def testIncludeWhatYouUseNoImplementationFiles(self):
     code = 'std::vector<int> foo;'
     for extension in ['h', 'hpp', 'hxx', 'h++', 'cuh']:
-      self.assertEquals('Add #include <vector> for vector<>'
+      self.assertEqual('Add #include <vector> for vector<>'
                        '  [build/include_what_you_use] [4]',
                        self.PerformIncludeWhatYouUse(code, 'foo.' + extension))
     for extension in ['c', 'cc', 'cpp', 'cxx', 'c++', 'cu']:
-      self.assertEquals('',
+      self.assertEqual('',
                        self.PerformIncludeWhatYouUse(code, 'foo.' + extension))
 
   def testIncludeWhatYouUse(self):
@@ -1270,7 +1271,7 @@ class CpplintTest(CpplintTestBase):
         '#include "blah/a.h"',
         filename='blah/a.cc',
         io=MockIo(mock_header_contents))
-    self.assertEquals(message, '')
+    self.assertEqual(message, '')
 
     mock_header_contents = ['#include <set>']
     message = self.PerformIncludeWhatYouUse(
@@ -1278,7 +1279,7 @@ class CpplintTest(CpplintTestBase):
            std::set<int> foo;""",
         filename='blah/a.cc',
         io=MockIo(mock_header_contents))
-    self.assertEquals(message, '')
+    self.assertEqual(message, '')
 
     # Make sure we can find the correct header file if the cc file seems to be
     # a temporary file generated by Emacs's flymake.
@@ -1288,7 +1289,7 @@ class CpplintTest(CpplintTestBase):
            std::set<int> foo;""",
         filename='blah/a_flymake.cc',
         io=MockIo(mock_header_contents))
-    self.assertEquals(message, 'Add #include <set> for set<>  '
+    self.assertEqual(message, 'Add #include <set> for set<>  '
                       '[build/include_what_you_use] [4]')
 
     # If there's just a cc and the header can't be found then it's ok.
@@ -1296,7 +1297,7 @@ class CpplintTest(CpplintTestBase):
         """#include "blah/a.h"
            std::set<int> foo;""",
         filename='blah/a.cc')
-    self.assertEquals(message, '')
+    self.assertEqual(message, '')
 
     # Make sure we find the headers with relative paths.
     mock_header_contents = ['']
@@ -1305,46 +1306,46 @@ class CpplintTest(CpplintTestBase):
            std::set<int> foo;""" % os.path.basename(os.getcwd()),
         filename='a.cc',
         io=MockIo(mock_header_contents))
-    self.assertEquals(message, 'Add #include <set> for set<>  '
+    self.assertEqual(message, 'Add #include <set> for set<>  '
                       '[build/include_what_you_use] [4]')
 
   def testFilesBelongToSameModule(self):
     f = cpplint.FilesBelongToSameModule
-    self.assertEquals((True, ''), f('a.cc', 'a.h'))
-    self.assertEquals((True, ''), f('base/google.cc', 'base/google.h'))
-    self.assertEquals((True, ''), f('base/google_test.c', 'base/google.h'))
-    self.assertEquals((True, ''), f('base/google_test.cc', 'base/google.h'))
-    self.assertEquals((True, ''), f('base/google_test.cc', 'base/google.hpp'))
-    self.assertEquals((True, ''), f('base/google_test.cxx', 'base/google.hxx'))
-    self.assertEquals((True, ''), f('base/google_test.cpp', 'base/google.hpp'))
-    self.assertEquals((True, ''), f('base/google_test.c++', 'base/google.h++'))
-    self.assertEquals((True, ''), f('base/google_test.cu', 'base/google.cuh'))
-    self.assertEquals((True, ''),
+    self.assertEqual((True, ''), f('a.cc', 'a.h'))
+    self.assertEqual((True, ''), f('base/google.cc', 'base/google.h'))
+    self.assertEqual((True, ''), f('base/google_test.c', 'base/google.h'))
+    self.assertEqual((True, ''), f('base/google_test.cc', 'base/google.h'))
+    self.assertEqual((True, ''), f('base/google_test.cc', 'base/google.hpp'))
+    self.assertEqual((True, ''), f('base/google_test.cxx', 'base/google.hxx'))
+    self.assertEqual((True, ''), f('base/google_test.cpp', 'base/google.hpp'))
+    self.assertEqual((True, ''), f('base/google_test.c++', 'base/google.h++'))
+    self.assertEqual((True, ''), f('base/google_test.cu', 'base/google.cuh'))
+    self.assertEqual((True, ''),
                       f('base/google_unittest.cc', 'base/google.h'))
-    self.assertEquals((True, ''),
+    self.assertEqual((True, ''),
                       f('base/internal/google_unittest.cc',
                         'base/public/google.h'))
-    self.assertEquals((True, 'xxx/yyy/'),
+    self.assertEqual((True, 'xxx/yyy/'),
                       f('xxx/yyy/base/internal/google_unittest.cc',
                         'base/public/google.h'))
-    self.assertEquals((True, 'xxx/yyy/'),
+    self.assertEqual((True, 'xxx/yyy/'),
                       f('xxx/yyy/base/google_unittest.cc',
                         'base/public/google.h'))
-    self.assertEquals((True, ''),
+    self.assertEqual((True, ''),
                       f('base/google_unittest.cc', 'base/google-inl.h'))
-    self.assertEquals((True, '/home/build/google3/'),
+    self.assertEqual((True, '/home/build/google3/'),
                       f('/home/build/google3/base/google.cc', 'base/google.h'))
 
-    self.assertEquals((False, ''),
+    self.assertEqual((False, ''),
                       f('/home/build/google3/base/google.cc', 'basu/google.h'))
-    self.assertEquals((False, ''), f('a.cc', 'b.h'))
+    self.assertEqual((False, ''), f('a.cc', 'b.h'))
 
   def testCleanseLine(self):
-    self.assertEquals('int foo = 0;',
+    self.assertEqual('int foo = 0;',
                       cpplint.CleanseComments('int foo = 0;  // danger!'))
-    self.assertEquals('int o = 0;',
+    self.assertEqual('int o = 0;',
                       cpplint.CleanseComments('int /* foo */ o = 0;'))
-    self.assertEquals('foo(int a, int b);',
+    self.assertEqual('foo(int a, int b);',
                       cpplint.CleanseComments('foo(int a /* abc */, int b);'))
     self.assertEqual('f(a, b);',
                      cpplint.CleanseComments('f(a, /* name */ b);'))
@@ -1482,7 +1483,7 @@ class CpplintTest(CpplintTestBase):
                               ['const char* str = "This is a\\',
                                ' multiline string.";'],
                               error_collector)
-      self.assertEquals(
+      self.assertEqual(
           2,  # One per line.
           error_collector.ResultList().count(multiline_string_error_message))
 
@@ -1835,7 +1836,7 @@ class CpplintTest(CpplintTestBase):
           '  explicit Foo(const int arg, Args&&... args) {}',
           '};'],
           error_collector)
-      self.assertEquals(0, error_collector.ResultList().count(
+      self.assertEqual(0, error_collector.ResultList().count(
         'Constructors that require multiple arguments should not be marked '
         'explicit.  [runtime/explicit] [0]'))
       error_collector = ErrorCollector(self.assert_)
@@ -1845,7 +1846,7 @@ class CpplintTest(CpplintTestBase):
           '  explicit Foo(Args&&... args) {}',
           '};'],
           error_collector)
-      self.assertEquals(0, error_collector.ResultList().count(
+      self.assertEqual(0, error_collector.ResultList().count(
         'Constructors that require multiple arguments should not be marked '
         'explicit.  [runtime/explicit] [0]'))
       error_collector = ErrorCollector(self.assert_)
@@ -1855,7 +1856,7 @@ class CpplintTest(CpplintTestBase):
           '  Foo(const int arg, Args&&... args) {}',
           '};'],
           error_collector)
-      self.assertEquals(1, error_collector.ResultList().count(
+      self.assertEqual(1, error_collector.ResultList().count(
         'Constructors callable with one argument should be marked explicit.'
         '  [runtime/explicit] [5]'))
       error_collector = ErrorCollector(self.assert_)
@@ -1865,7 +1866,7 @@ class CpplintTest(CpplintTestBase):
           '  Foo(Args&&... args) {}',
           '};'],
           error_collector)
-      self.assertEquals(1, error_collector.ResultList().count(
+      self.assertEqual(1, error_collector.ResultList().count(
         'Constructors callable with one argument should be marked explicit.'
         '  [runtime/explicit] [5]'))
       # Anything goes inside an assembly block
@@ -1880,16 +1881,16 @@ class CpplintTest(CpplintTestBase):
                                '  }',
                                '}'],
                               error_collector)
-      self.assertEquals(
+      self.assertEqual(
           0,
           error_collector.ResultList().count(
               'Extra space before ( in function call  [whitespace/parens] [4]'))
-      self.assertEquals(
+      self.assertEqual(
           0,
           error_collector.ResultList().count(
               'Closing ) should be moved to the previous line  '
               '[whitespace/parens] [2]'))
-      self.assertEquals(
+      self.assertEqual(
           0,
           error_collector.ResultList().count(
               'Extra space before [  [whitespace/braces] [5]'))
@@ -1992,7 +1993,7 @@ class CpplintTest(CpplintTestBase):
            '    LOCKS_EXCLUDED(lock) ' + virt_specifier + ';',
            ''],
           error_collector)
-      self.assertEquals(
+      self.assertEqual(
           [error_message, error_message, error_message],
           error_collector.Results())
 
@@ -2018,7 +2019,7 @@ class CpplintTest(CpplintTestBase):
          '}',
          ''],
         error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
 
     self.TestLint('void Finalize(AnnotationProto *final) override;', '')
 
@@ -2189,7 +2190,7 @@ class CpplintTest(CpplintTestBase):
            '};',
            ''],
           error_collector)
-      self.assertEquals(
+      self.assertEqual(
           ('%s should be the last thing in the class' % macro_name) +
           '  [readability/constructors] [3]',
           error_collector.Results())
@@ -2208,7 +2209,7 @@ class CpplintTest(CpplintTestBase):
            '};',
            ''],
           error_collector)
-      self.assertEquals(
+      self.assertEqual(
           ('%s should be the last thing in the class' % macro_name) +
           '  [readability/constructors] [3]',
           error_collector.Results())
@@ -2245,7 +2246,7 @@ class CpplintTest(CpplintTestBase):
            '}',
            ''],
           error_collector)
-      self.assertEquals('', error_collector.Results())
+      self.assertEqual('', error_collector.Results())
 
   # Brace usage
   def testBraces(self):
@@ -2554,7 +2555,7 @@ class CpplintTest(CpplintTestBase):
          'void f(int& q) {}',
          ''],
         error_collector)
-    self.assertEquals(
+    self.assertEqual(
         operand_error_message % 'int& q',
         error_collector.Results())
 
@@ -2600,7 +2601,7 @@ class CpplintTest(CpplintTestBase):
          '      initializer2_(a6 & b6) {}',
          ''],
         error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
 
     # Multi-line references
     error_collector = ErrorCollector(self.assert_)
@@ -2622,7 +2623,7 @@ class CpplintTest(CpplintTestBase):
          '}',
          ''],
         error_collector)
-    self.assertEquals(
+    self.assertEqual(
         [operand_error_message % 'Outer::Inner& nonconst_x',
          operand_error_message % 'Outer::Inner& nonconst_y',
          operand_error_message % 'Outer<int>::Inner& nonconst_z'],
@@ -2642,7 +2643,7 @@ class CpplintTest(CpplintTestBase):
          '}',
          ''],
         error_collector.Results())
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
 
   def testBraceAtBeginOfLine(self):
     self.TestLint('{',
@@ -2671,7 +2672,7 @@ class CpplintTest(CpplintTestBase):
                              '}',
                              '#endif'],
                             error_collector)
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         '{ should almost always be at the end of the previous line'
         '  [whitespace/braces] [4]'))
 
@@ -3183,7 +3184,7 @@ class CpplintTest(CpplintTestBase):
                              'static_member_variable5;',
                              ''],
                             error_collector)
-    self.assertEquals(error_collector.Results(),
+    self.assertEqual(error_collector.Results(),
                       [error_msg % 'const char Class::static_member_variable1',
                        error_msg % 'const char Class::static_member_variable2',
                        error_msg % 'const char Class::static_member_variable3',
@@ -3314,7 +3315,7 @@ class CpplintTest(CpplintTestBase):
       error_collector = ErrorCollector(self.assert_)
       cpplint.ProcessFileData('foo.cc', 'cc', lines, error_collector)
       # The warning appears only once.
-      self.assertEquals(
+      self.assertEqual(
           1,
           error_collector.Results().count(
               'Do not use namespace using-directives.  '
@@ -3338,7 +3339,7 @@ class CpplintTest(CpplintTestBase):
       cpplint.ProcessFileData('foo.cc', 'cc', data.split('\n'),
                               error_collector)
       # The warning appears only once.
-      self.assertEquals(
+      self.assertEqual(
           int(is_missing_eof),
           error_collector.Results().count(
               'Could not find a newline character at the end of the file.'
@@ -3359,7 +3360,7 @@ class CpplintTest(CpplintTestBase):
           unidata,
           error_collector)
       # The warning appears only once.
-      self.assertEquals(
+      self.assertEqual(
           int(has_invalid_utf8),
           error_collector.Results().count(
               'Line contains invalid UTF-8'
@@ -3379,7 +3380,7 @@ class CpplintTest(CpplintTestBase):
     cpplint.ProcessFileData('nul.cc', 'cc',
                             ['// Copyright 2014 Your Company.',
                              '\0', ''], error_collector)
-    self.assertEquals(
+    self.assertEqual(
         error_collector.Results(),
         'Line contains NUL byte.  [readability/nul] [5]')
 
@@ -3397,7 +3398,7 @@ class CpplintTest(CpplintTestBase):
          unidata,
          ''],
         error_collector)
-    self.assertEquals(
+    self.assertEqual(
         error_collector.Results(),
         ['Line contains invalid UTF-8 (or Unicode replacement character).'
          '  [readability/utf8] [5]',
@@ -3447,7 +3448,7 @@ class CpplintTest(CpplintTestBase):
                              '', '', '', '',
                              '}'],
                             error_collector)
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'Redundant blank line at the end of a code block should be deleted.'
         '  [whitespace/blank_line] [3]'))
 
@@ -3464,7 +3465,7 @@ class CpplintTest(CpplintTestBase):
                              '',  # Warning on this line
                              '}'],
                             error_collector)
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'Redundant blank line at the end of a code block should be deleted.'
         '  [whitespace/blank_line] [3]'))
 
@@ -3477,10 +3478,10 @@ class CpplintTest(CpplintTestBase):
                              '',
                              '}'],
                             error_collector)
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'Redundant blank line at the start of a code block should be deleted.'
         '  [whitespace/blank_line] [2]'))
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'Redundant blank line at the end of a code block should be deleted.'
         '  [whitespace/blank_line] [3]'))
 
@@ -3513,10 +3514,10 @@ class CpplintTest(CpplintTestBase):
                              '  int a;\\',
                              '};'],
                             error_collector)
-    self.assertEquals(2, error_collector.Results().count(
+    self.assertEqual(2, error_collector.Results().count(
         '"private:" should be preceded by a blank line'
         '  [whitespace/blank_line] [3]'))
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         '"protected:" should be preceded by a blank line'
         '  [whitespace/blank_line] [3]'))
 
@@ -3534,13 +3535,13 @@ class CpplintTest(CpplintTestBase):
                              '  };',
                              '};'],
                             error_collector)
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'Do not leave a blank line after "public:"'
         '  [whitespace/blank_line] [3]'))
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'Do not leave a blank line after "protected:"'
         '  [whitespace/blank_line] [3]'))
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'Do not leave a blank line after "private:"'
         '  [whitespace/blank_line] [3]'))
 
@@ -3555,7 +3556,7 @@ class CpplintTest(CpplintTestBase):
                              ')"};',
                              ''],
                             error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
 
   def testElseOnSameLineAsClosingBraces(self):
     error_collector = ErrorCollector(self.assert_)
@@ -3568,7 +3569,7 @@ class CpplintTest(CpplintTestBase):
                              '',
                              '}'],
                             error_collector)
-    self.assertEquals(2, error_collector.Results().count(
+    self.assertEqual(2, error_collector.Results().count(
         'An else should appear on the same line as the preceding }'
         '  [whitespace/newline] [4]'))
 
@@ -3582,7 +3583,7 @@ class CpplintTest(CpplintTestBase):
                              '',
                              '}'],
                             error_collector)
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'An else should appear on the same line as the preceding }'
         '  [whitespace/newline] [4]'))
 
@@ -3593,7 +3594,7 @@ class CpplintTest(CpplintTestBase):
                              '}',
                              'else_function();'],
                             error_collector)
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'An else should appear on the same line as the preceding }'
         '  [whitespace/newline] [4]'))
 
@@ -3606,7 +3607,7 @@ class CpplintTest(CpplintTestBase):
                              '}',
                              'sum += MathUtil::SafeIntRound(x); x += 0.1;'],
                             error_collector)
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'More than one command on the same line  [whitespace/newline] [0]'))
 
     old_verbose_level = cpplint._cpplint_state.verbose_level
@@ -3625,7 +3626,7 @@ class CpplintTest(CpplintTestBase):
                               '[](const int i) { return i; };'],
                             error_collector)
     cpplint._cpplint_state.verbose_level = old_verbose_level
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'More than one command on the same line  [whitespace/newline] [0]'))
 
     error_collector = ErrorCollector(self.assert_)
@@ -3637,7 +3638,7 @@ class CpplintTest(CpplintTestBase):
                               '[](const int i) { return i > 0; });'],
                             error_collector)
     cpplint._cpplint_state.verbose_level = old_verbose_level
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'More than one command on the same line  [whitespace/newline] [0]'))
 
     error_collector = ErrorCollector(self.assert_)
@@ -3649,7 +3650,7 @@ class CpplintTest(CpplintTestBase):
                               'this->ReadUnlock(); });'],
                             error_collector)
     cpplint._cpplint_state.verbose_level = old_verbose_level
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'More than one command on the same line  [whitespace/newline] [0]'))
 
     error_collector = ErrorCollector(self.assert_)
@@ -3661,7 +3662,7 @@ class CpplintTest(CpplintTestBase):
                               'this->ReadUnlock(); }, object);'],
                             error_collector)
     cpplint._cpplint_state.verbose_level = old_verbose_level
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'More than one command on the same line  [whitespace/newline] [0]'))
 
   def testEndOfNamespaceComments(self):
@@ -3708,26 +3709,26 @@ class CpplintTest(CpplintTestBase):
                             ['}  /* namespace c_style. */ \\',
                              ';'],
                             error_collector)
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'Namespace should be terminated with "// namespace expected"'
         '  [readability/namespace] [5]'))
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'Namespace should be terminated with "// namespace outer"'
         '  [readability/namespace] [5]'))
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'Namespace should be terminated with "// namespace nested"'
         '  [readability/namespace] [5]'))
-    self.assertEquals(3, error_collector.Results().count(
+    self.assertEqual(3, error_collector.Results().count(
         'Anonymous namespace should be terminated with "// namespace"'
         '  [readability/namespace] [5]'))
-    self.assertEquals(2, error_collector.Results().count(
+    self.assertEqual(2, error_collector.Results().count(
         'Anonymous namespace should be terminated with "// namespace" or'
         ' "// anonymous namespace"'
         '  [readability/namespace] [5]'))
-    self.assertEquals(1, error_collector.Results().count(
+    self.assertEqual(1, error_collector.Results().count(
         'Namespace should be terminated with "// namespace missing_comment"'
         '  [readability/namespace] [5]'))
-    self.assertEquals(0, error_collector.Results().count(
+    self.assertEqual(0, error_collector.Results().count(
         'Namespace should be terminated with "// namespace no_warning"'
         '  [readability/namespace] [5]'))
 
@@ -4192,38 +4193,38 @@ class CpplintTest(CpplintTestBase):
                         ['--filter=+a,b,-c'])
       self.assertRaises(SystemExit, cpplint.ParseArguments, ['--headers'])
 
-      self.assertEquals(['foo.cc'], cpplint.ParseArguments(['foo.cc']))
-      self.assertEquals(old_output_format, cpplint._cpplint_state.output_format)
-      self.assertEquals(old_verbose_level, cpplint._cpplint_state.verbose_level)
+      self.assertEqual(['foo.cc'], cpplint.ParseArguments(['foo.cc']))
+      self.assertEqual(old_output_format, cpplint._cpplint_state.output_format)
+      self.assertEqual(old_verbose_level, cpplint._cpplint_state.verbose_level)
 
-      self.assertEquals(['foo.cc'],
+      self.assertEqual(['foo.cc'],
                         cpplint.ParseArguments(['--v=1', 'foo.cc']))
-      self.assertEquals(1, cpplint._cpplint_state.verbose_level)
-      self.assertEquals(['foo.h'],
+      self.assertEqual(1, cpplint._cpplint_state.verbose_level)
+      self.assertEqual(['foo.h'],
                         cpplint.ParseArguments(['--v=3', 'foo.h']))
-      self.assertEquals(3, cpplint._cpplint_state.verbose_level)
-      self.assertEquals(['foo.cpp'],
+      self.assertEqual(3, cpplint._cpplint_state.verbose_level)
+      self.assertEqual(['foo.cpp'],
                         cpplint.ParseArguments(['--verbose=5', 'foo.cpp']))
-      self.assertEquals(5, cpplint._cpplint_state.verbose_level)
+      self.assertEqual(5, cpplint._cpplint_state.verbose_level)
       self.assertRaises(ValueError,
                         cpplint.ParseArguments, ['--v=f', 'foo.cc'])
 
-      self.assertEquals(['foo.cc'],
+      self.assertEqual(['foo.cc'],
                         cpplint.ParseArguments(['--output=emacs', 'foo.cc']))
-      self.assertEquals('emacs', cpplint._cpplint_state.output_format)
-      self.assertEquals(['foo.h'],
+      self.assertEqual('emacs', cpplint._cpplint_state.output_format)
+      self.assertEqual(['foo.h'],
                         cpplint.ParseArguments(['--output=vs7', 'foo.h']))
-      self.assertEquals('vs7', cpplint._cpplint_state.output_format)
+      self.assertEqual('vs7', cpplint._cpplint_state.output_format)
       self.assertRaises(SystemExit,
                         cpplint.ParseArguments, ['--output=blah', 'foo.cc'])
 
       filt = '-,+whitespace,-whitespace/indent'
-      self.assertEquals(['foo.h'],
+      self.assertEqual(['foo.h'],
                         cpplint.ParseArguments(['--filter='+filt, 'foo.h']))
-      self.assertEquals(['-', '+whitespace', '-whitespace/indent'],
+      self.assertEqual(['-', '+whitespace', '-whitespace/indent'],
                         cpplint._cpplint_state.filters)
 
-      self.assertEquals(['foo.cc', 'foo.h'],
+      self.assertEqual(['foo.cc', 'foo.h'],
                         cpplint.ParseArguments(['foo.cc', 'foo.h']))
 
       cpplint._hpp_headers = old_headers
@@ -4278,7 +4279,7 @@ class CpplintTest(CpplintTestBase):
                   os.path.join('src', 'nested', 'three.cpp')]
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['--recursive', 'one.cpp', 'src'])
-      self.assertEquals(set(expected), set(actual))
+      self.assertEqual(set(expected), set(actual))
     finally:
         os.chdir(working_dir)
         shutil.rmtree(temp_dir)
@@ -4297,7 +4298,7 @@ class CpplintTest(CpplintTestBase):
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['--recursive', '--extensions=cpp',
           'one.cpp', 'src'])
-      self.assertEquals(set(expected), set(actual))
+      self.assertEqual(set(expected), set(actual))
     finally:
         os.chdir(working_dir)
         shutil.rmtree(temp_dir)
@@ -4327,23 +4328,23 @@ class CpplintTest(CpplintTestBase):
       ]
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['src'])
-      self.assertEquals(set(['src']), set(actual))
+      self.assertEqual(set(['src']), set(actual))
 
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['--recursive', 'src'])
-      self.assertEquals(set(expected), set(actual))
+      self.assertEqual(set(expected), set(actual))
 
       expected = [os.path.join('src', 'one.cc')]
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['--recursive',
           '--exclude=src{0}t*'.format(os.sep), 'src'])
-      self.assertEquals(set(expected), set(actual))
+      self.assertEqual(set(expected), set(actual))
 
       expected = [os.path.join('src', 'one.cc')]
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['--recursive',
           '--exclude=src/two.cc', '--exclude=src/three.cc', 'src'])
-      self.assertEquals(set(expected), set(actual))
+      self.assertEqual(set(expected), set(actual))
 
       expected = set([
         os.path.join('src2', 'one.cc'),
@@ -4353,7 +4354,7 @@ class CpplintTest(CpplintTestBase):
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['--recursive',
           '--exclude=src', '.'])
-      self.assertEquals(expected, set(actual))
+      self.assertEqual(expected, set(actual))
     finally:
         os.chdir(working_dir)
         shutil.rmtree(temp_dir)
@@ -4366,7 +4367,7 @@ class CpplintTest(CpplintTestBase):
           '<testsuite errors="0" failures="0" name="cpplint" tests="1">'
           '<testcase name="passed" />'
           '</testsuite>')
-      self.assertEquals(expected, cpplint._cpplint_state.FormatJUnitXML())
+      self.assertEqual(expected, cpplint._cpplint_state.FormatJUnitXML())
 
       cpplint._cpplint_state._junit_errors = ['ErrMsg1']
       cpplint._cpplint_state._junit_failures = []
@@ -4374,7 +4375,7 @@ class CpplintTest(CpplintTestBase):
           '<testsuite errors="1" failures="0" name="cpplint" tests="1">'
           '<testcase name="errors"><error>ErrMsg1</error></testcase>'
           '</testsuite>')
-      self.assertEquals(expected, cpplint._cpplint_state.FormatJUnitXML())
+      self.assertEqual(expected, cpplint._cpplint_state.FormatJUnitXML())
 
       cpplint._cpplint_state._junit_errors = ['ErrMsg1', 'ErrMsg2']
       cpplint._cpplint_state._junit_failures = []
@@ -4382,7 +4383,7 @@ class CpplintTest(CpplintTestBase):
           '<testsuite errors="2" failures="0" name="cpplint" tests="2">'
           '<testcase name="errors"><error>ErrMsg1\nErrMsg2</error></testcase>'
           '</testsuite>')
-      self.assertEquals(expected, cpplint._cpplint_state.FormatJUnitXML())
+      self.assertEqual(expected, cpplint._cpplint_state.FormatJUnitXML())
 
       cpplint._cpplint_state._junit_errors = ['ErrMsg']
       cpplint._cpplint_state._junit_failures = [
@@ -4392,7 +4393,7 @@ class CpplintTest(CpplintTestBase):
           '<testcase name="errors"><error>ErrMsg</error></testcase>'
           '<testcase name="File"><failure>5: FailMsg [category/subcategory] '
           '[3]</failure></testcase></testsuite>')
-      self.assertEquals(expected, cpplint._cpplint_state.FormatJUnitXML())
+      self.assertEqual(expected, cpplint._cpplint_state.FormatJUnitXML())
 
       cpplint._cpplint_state._junit_errors = []
       cpplint._cpplint_state._junit_failures = [
@@ -4405,7 +4406,7 @@ class CpplintTest(CpplintTestBase):
           ' [3]\n19: FailMsg3 [category/subcategory] [3]</failure></testcase>'
           '<testcase name="File2"><failure>99: FailMsg2 '
           '[category/subcategory] [3]</failure></testcase></testsuite>')
-      self.assertEquals(expected, cpplint._cpplint_state.FormatJUnitXML())
+      self.assertEqual(expected, cpplint._cpplint_state.FormatJUnitXML())
 
       cpplint._cpplint_state._junit_errors = ['&</error>']
       cpplint._cpplint_state._junit_failures = [
@@ -4416,16 +4417,16 @@ class CpplintTest(CpplintTestBase):
           '</testcase><testcase name="File1"><failure>5: '
           '&amp;&lt;/failure&gt; [category/subcategory] [3]</failure>'
           '</testcase></testsuite>')
-      self.assertEquals(expected, cpplint._cpplint_state.FormatJUnitXML())
+      self.assertEqual(expected, cpplint._cpplint_state.FormatJUnitXML())
 
     finally:
       cpplint._cpplint_state._junit_errors = []
       cpplint._cpplint_state._junit_failures = []
 
   def testQuiet(self):
-    self.assertEquals(cpplint._cpplint_state.quiet, False)
+    self.assertEqual(cpplint._cpplint_state.quiet, False)
     cpplint.ParseArguments(['--quiet', 'one.cpp'])
-    self.assertEquals(cpplint._cpplint_state.quiet, True)
+    self.assertEqual(cpplint._cpplint_state.quiet, True)
 
   def testLineLength(self):
     old_line_length = cpplint._line_length
@@ -4494,7 +4495,7 @@ class CpplintTest(CpplintTestBase):
                              '#endif',
                              ''],
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         ['"path/duplicate.h" already included at path/self.cc:3  '
          '[build/include] [4]'],
         error_collector.ResultList())
@@ -4603,7 +4604,7 @@ class CpplintTest(CpplintTestBase):
     # No guard at all: expect one error.
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData(file_path, 'h', [], error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             'No #ifndef header guard found, suggested CPP variable is: %s'
@@ -4616,13 +4617,13 @@ class CpplintTest(CpplintTestBase):
                             ['// Copyright 2014 Your Company.',
                              '// NOLINT(build/header_guard)', ''],
                             error_collector)
-    self.assertEquals([], error_collector.ResultList())
+    self.assertEqual([], error_collector.ResultList())
 
     # Wrong guard
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef FOO_H', '#define FOO_H'], error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             '#ifndef header guard has wrong style, please use: %s'
@@ -4633,7 +4634,7 @@ class CpplintTest(CpplintTestBase):
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData(file_path, 'h',
                             ['#ifndef %s' % expected_guard], error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             'No #ifndef header guard found, suggested CPP variable is: %s'
@@ -4646,7 +4647,7 @@ class CpplintTest(CpplintTestBase):
                             ['#ifndef %s' % expected_guard,
                              '#define FOO_H'],
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             'No #ifndef header guard found, suggested CPP variable is: %s'
@@ -4660,7 +4661,7 @@ class CpplintTest(CpplintTestBase):
                              '#define %s' % expected_guard,
                              ''],
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             '#endif line should be "#endif  // %s"'
@@ -4674,7 +4675,7 @@ class CpplintTest(CpplintTestBase):
                              '#define %s' % expected_guard,
                              '#endif'],
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             '#endif line should be "#endif  // %s"'
@@ -4688,7 +4689,7 @@ class CpplintTest(CpplintTestBase):
                              '#define %s_' % expected_guard,
                              '#endif'],
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             '#endif line should be "#endif  // %s"'
@@ -4727,7 +4728,7 @@ class CpplintTest(CpplintTestBase):
                                '#define %s_' % expected_guard,
                                '#endif  // %s_' % expected_guard],
                               error_collector)
-      self.assertEquals(
+      self.assertEqual(
           1,
           error_collector.ResultList().count(
               '#ifndef header guard has wrong style, please use: %s'
@@ -4743,13 +4744,13 @@ class CpplintTest(CpplintTestBase):
                              '#define FOO',
                              '#endif  // FOO'],
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             '#ifndef header guard has wrong style, please use: %s'
             '  [build/header_guard] [5]' % expected_guard),
         error_collector.ResultList())
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             '#endif line should be "#endif  // %s"'
@@ -4763,13 +4764,13 @@ class CpplintTest(CpplintTestBase):
                              '#define FOO',
                              '#endif  // FOO NOLINT'],
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         0,
         error_collector.ResultList().count(
             '#ifndef header guard has wrong style, please use: %s'
             '  [build/header_guard] [5]' % expected_guard),
         error_collector.ResultList())
-    self.assertEquals(
+    self.assertEqual(
         0,
         error_collector.ResultList().count(
             '#endif line should be "#endif  // %s"'
@@ -4782,7 +4783,7 @@ class CpplintTest(CpplintTestBase):
       cpplint.ProcessFileData(test_file, 'h',
                               ['// Copyright 2014 Your Company.', ''],
                               error_collector)
-      self.assertEquals(
+      self.assertEqual(
           1,
           error_collector.ResultList().count(
               'No #ifndef header guard found, suggested CPP variable is: %s'
@@ -4798,13 +4799,13 @@ class CpplintTest(CpplintTestBase):
                              '#define FOO',
                              '#endif  // FOO'],
                             error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             '#ifndef header guard has wrong style, please use: %s'
             '  [build/header_guard] [5]' % expected_guard),
         error_collector.ResultList())
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(
             '#endif line should be "#endif  // %s"'
@@ -4816,7 +4817,7 @@ class CpplintTest(CpplintTestBase):
     cpplint.ProcessFileData('mydir/foo.h', 'h',
         ['// Copyright 2014 Your Company.', '#pragma once', ''],
         error_collector)
-    self.assertEquals([], error_collector.ResultList())
+    self.assertEqual([], error_collector.ResultList())
 
   def testBuildHeaderGuardWithRoot(self):
     temp_directory = os.path.realpath(tempfile.mkdtemp())
@@ -4847,7 +4848,7 @@ class CpplintTest(CpplintTestBase):
       # when the root directory of the repository is properly deduced.
       return
 
-    self.assertEquals('CPPLINT_CPPLINT_TEST_HEADER_H_',
+    self.assertEqual('CPPLINT_CPPLINT_TEST_HEADER_H_',
                       cpplint.GetHeaderGuardCPPVariable(file_path))
     #
     # test --root flags:
@@ -4857,7 +4858,7 @@ class CpplintTest(CpplintTestBase):
     # left-strip the header guard by using a root dir inside of the repo dir.
     # relative directory
     cpplint._root = 'cpplint'
-    self.assertEquals('CPPLINT_TEST_HEADER_H_',
+    self.assertEqual('CPPLINT_TEST_HEADER_H_',
                       cpplint.GetHeaderGuardCPPVariable(file_path))
 
     nested_header_directory = os.path.join(header_directory, "nested")
@@ -4867,22 +4868,22 @@ class CpplintTest(CpplintTestBase):
 
     cpplint._root = os.path.join('cpplint', 'nested')
     actual = cpplint.GetHeaderGuardCPPVariable(nested_file_path)
-    self.assertEquals('CPPLINT_TEST_HEADER_H_',
+    self.assertEqual('CPPLINT_TEST_HEADER_H_',
                       actual)
 
     # absolute directory
     # (note that CPPLINT.cfg root=setting is always made absolute)
     cpplint._root = header_directory
-    self.assertEquals('CPPLINT_TEST_HEADER_H_',
+    self.assertEqual('CPPLINT_TEST_HEADER_H_',
                       cpplint.GetHeaderGuardCPPVariable(file_path))
 
     cpplint._root = nested_header_directory
-    self.assertEquals('CPPLINT_TEST_HEADER_H_',
+    self.assertEqual('CPPLINT_TEST_HEADER_H_',
                       cpplint.GetHeaderGuardCPPVariable(nested_file_path))
 
     # --root flag is ignored if an non-existent directory is specified.
     cpplint._root = 'NON_EXISTENT_DIR'
-    self.assertEquals('CPPLINT_CPPLINT_TEST_HEADER_H_',
+    self.assertEqual('CPPLINT_CPPLINT_TEST_HEADER_H_',
                       cpplint.GetHeaderGuardCPPVariable(file_path))
 
     # prepend to the header guard by using a root dir that is more outer
@@ -4899,7 +4900,7 @@ class CpplintTest(CpplintTestBase):
     # do not hardcode the 'styleguide' repository name, it could be anything.
     expected_prefix = re.sub(r'[^a-zA-Z0-9]', '_', styleguide_dir_name).upper() + '_'
     # do not have 'styleguide' repo in '/'
-    self.assertEquals('%sCPPLINT_CPPLINT_TEST_HEADER_H_' % (expected_prefix),
+    self.assertEqual('%sCPPLINT_CPPLINT_TEST_HEADER_H_' % (expected_prefix),
                       cpplint.GetHeaderGuardCPPVariable(file_path))
 
     # To run the 'relative path' tests, we must be in the directory of this test file.
@@ -4910,13 +4911,13 @@ class CpplintTest(CpplintTestBase):
     styleguide_rel_path = os.path.relpath(styleguide_path, this_files_path)
     # '..'
     cpplint._root = styleguide_rel_path
-    self.assertEquals('CPPLINT_CPPLINT_TEST_HEADER_H_',
+    self.assertEqual('CPPLINT_CPPLINT_TEST_HEADER_H_',
                       cpplint.GetHeaderGuardCPPVariable(file_path))
 
     styleguide_rel_path = os.path.relpath(styleguide_parent_path,
                                           this_files_path)  # '../..'
     cpplint._root = styleguide_rel_path
-    self.assertEquals('%sCPPLINT_CPPLINT_TEST_HEADER_H_' % (expected_prefix),
+    self.assertEqual('%sCPPLINT_CPPLINT_TEST_HEADER_H_' % (expected_prefix),
                       cpplint.GetHeaderGuardCPPVariable(file_path))
 
     cpplint._root = None
@@ -5010,19 +5011,19 @@ class CpplintTest(CpplintTestBase):
       shutil.rmtree(temp_directory)
 
   def testPathSplitToList(self):
-    self.assertEquals([''],
+    self.assertEqual([''],
                       cpplint.PathSplitToList(os.path.join('')))
 
-    self.assertEquals(['.'],
+    self.assertEqual(['.'],
                       cpplint.PathSplitToList(os.path.join('.')))
 
-    self.assertEquals(['..'],
+    self.assertEqual(['..'],
                       cpplint.PathSplitToList(os.path.join('..')))
 
-    self.assertEquals(['..', 'a', 'b'],
+    self.assertEqual(['..', 'a', 'b'],
                       cpplint.PathSplitToList(os.path.join('..', 'a', 'b')))
 
-    self.assertEquals(['a', 'b', 'c', 'd'],
+    self.assertEqual(['a', 'b', 'c', 'd'],
                       cpplint.PathSplitToList(os.path.join('a', 'b', 'c', 'd')))
 
   def testBuildHeaderGuardWithRepository(self):
@@ -5038,31 +5039,31 @@ class CpplintTest(CpplintTestBase):
       open(file_path, 'a').close()
 
       # search for .svn if _repository is not specified
-      self.assertEquals('TRUNK_CPPLINT_CPPLINT_TEST_HEADER_H_',
+      self.assertEqual('TRUNK_CPPLINT_CPPLINT_TEST_HEADER_H_',
                         cpplint.GetHeaderGuardCPPVariable(file_path))
 
       # use the provided repository root for header guards
       cpplint._repository = os.path.relpath(trunk_dir)
-      self.assertEquals('CPPLINT_CPPLINT_TEST_HEADER_H_',
+      self.assertEqual('CPPLINT_CPPLINT_TEST_HEADER_H_',
                         cpplint.GetHeaderGuardCPPVariable(file_path))
       cpplint._repository = os.path.abspath(trunk_dir)
-      self.assertEquals('CPPLINT_CPPLINT_TEST_HEADER_H_',
+      self.assertEqual('CPPLINT_CPPLINT_TEST_HEADER_H_',
                         cpplint.GetHeaderGuardCPPVariable(file_path))
 
       # ignore _repository if it doesnt exist
       cpplint._repository = os.path.join(temp_directory, 'NON_EXISTANT')
-      self.assertEquals('TRUNK_CPPLINT_CPPLINT_TEST_HEADER_H_',
+      self.assertEqual('TRUNK_CPPLINT_CPPLINT_TEST_HEADER_H_',
                         cpplint.GetHeaderGuardCPPVariable(file_path))
 
       # ignore _repository if it exists but file isn't in it
       cpplint._repository = os.path.relpath(temp_directory2)
-      self.assertEquals('TRUNK_CPPLINT_CPPLINT_TEST_HEADER_H_',
+      self.assertEqual('TRUNK_CPPLINT_CPPLINT_TEST_HEADER_H_',
                         cpplint.GetHeaderGuardCPPVariable(file_path))
 
       # _root should be relative to _repository
       cpplint._repository = os.path.relpath(trunk_dir)
       cpplint._root = 'cpplint'
-      self.assertEquals('CPPLINT_TEST_HEADER_H_',
+      self.assertEqual('CPPLINT_TEST_HEADER_H_',
                         cpplint.GetHeaderGuardCPPVariable(file_path))
 
     finally:
@@ -5100,7 +5101,7 @@ class CpplintTest(CpplintTestBase):
          r'fprintf(file, "\(%d", value);',
          r'vsnprintf(buffer, sizeof(buffer), "\\\{%d", ap);'],
         error_collector)
-    self.assertEquals(
+    self.assertEqual(
         4,
         error_collector.Results().count(
             '%, [, (, and { are undefined character escapes.  Unescape them.'
@@ -5115,7 +5116,7 @@ class CpplintTest(CpplintTestBase):
          r'printf(R"(\[%s)", R"(\])");',
          ''],
         error_collector)
-    self.assertEquals('', error_collector.Results())
+    self.assertEqual('', error_collector.Results())
 
   def testRuntimePrintfFormat(self):
     self.TestLint(
@@ -5227,7 +5228,7 @@ class CpplintTest(CpplintTestBase):
     # There should be a copyright message in the first 10 lines
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData(file_path, 'cc', [], error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(legal_copyright_message))
 
@@ -5236,7 +5237,7 @@ class CpplintTest(CpplintTestBase):
         file_path, 'cc',
         ['' for unused_i in range(10)] + [copyright_line],
         error_collector)
-    self.assertEquals(
+    self.assertEqual(
         1,
         error_collector.ResultList().count(legal_copyright_message))
 
@@ -5286,7 +5287,7 @@ class Cxx11Test(CpplintTestBase):
     collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData(filename, extension, lines, collector)
     error_list = collector.ResultList()
-    self.assertEquals(count, len(error_list), error_list)
+    self.assertEqual(count, len(error_list), error_list)
 
   def TestCxx11Feature(self, code, expected_error):
     lines = code.split('\n')
@@ -5294,7 +5295,7 @@ class Cxx11Test(CpplintTestBase):
     cpplint.RemoveMultiLineComments('foo.h', lines, collector)
     clean_lines = cpplint.CleansedLines(lines)
     cpplint.FlagCxx11Features('foo.cc', clean_lines, 0, collector)
-    self.assertEquals(expected_error, collector.Results())
+    self.assertEqual(expected_error, collector.Results())
 
   def testBlockedHeaders(self):
     self.TestCxx11Feature('#include <tr1/regex>',
@@ -5352,7 +5353,7 @@ class Cxx14Test(CpplintTestBase):
     cpplint.RemoveMultiLineComments('foo.h', lines, collector)
     clean_lines = cpplint.CleansedLines(lines)
     cpplint.FlagCxx14Features('foo.cc', clean_lines, 0, collector)
-    self.assertEquals(expected_error, collector.Results())
+    self.assertEqual(expected_error, collector.Results())
 
   def testBlockedHeaders(self):
     self.TestCxx14Feature('#include <scoped_allocator>',
@@ -5373,68 +5374,68 @@ class CleansedLinesTest(unittest.TestCase):
              'Line 5 "foo"']
 
     clean_lines = cpplint.CleansedLines(lines)
-    self.assertEquals(lines, clean_lines.raw_lines)
-    self.assertEquals(5, clean_lines.NumLines())
+    self.assertEqual(lines, clean_lines.raw_lines)
+    self.assertEqual(5, clean_lines.NumLines())
 
-    self.assertEquals(['Line 1',
-                       'Line 2',
-                       'Line 3',
-                       'Line 4',
-                       'Line 5 "foo"'],
-                      clean_lines.lines)
+    self.assertEqual(['Line 1',
+                      'Line 2',
+                      'Line 3',
+                      'Line 4',
+                      'Line 5 "foo"'],
+                     clean_lines.lines)
 
-    self.assertEquals(['Line 1',
-                       'Line 2',
-                       'Line 3',
-                       'Line 4',
-                       'Line 5 ""'],
-                      clean_lines.elided)
+    self.assertEqual(['Line 1',
+                      'Line 2',
+                      'Line 3',
+                      'Line 4',
+                      'Line 5 ""'],
+                     clean_lines.elided)
 
   def testInitEmpty(self):
     clean_lines = cpplint.CleansedLines([])
-    self.assertEquals([], clean_lines.raw_lines)
-    self.assertEquals(0, clean_lines.NumLines())
+    self.assertEqual([], clean_lines.raw_lines)
+    self.assertEqual(0, clean_lines.NumLines())
 
   def testCollapseStrings(self):
     collapse = cpplint.CleansedLines._CollapseStrings
-    self.assertEquals('""', collapse('""'))             # ""     (empty)
-    self.assertEquals('"""', collapse('"""'))           # """    (bad)
-    self.assertEquals('""', collapse('"xyz"'))          # "xyz"  (string)
-    self.assertEquals('""', collapse('"\\\""'))         # "\""   (string)
-    self.assertEquals('""', collapse('"\'"'))           # "'"    (string)
-    self.assertEquals('"\"', collapse('"\"'))           # "\"    (bad)
-    self.assertEquals('""', collapse('"\\\\"'))         # "\\"   (string)
-    self.assertEquals('"', collapse('"\\\\\\"'))        # "\\\"  (bad)
-    self.assertEquals('""', collapse('"\\\\\\\\"'))     # "\\\\" (string)
+    self.assertEqual('""', collapse('""'))             # ""     (empty)
+    self.assertEqual('"""', collapse('"""'))           # """    (bad)
+    self.assertEqual('""', collapse('"xyz"'))          # "xyz"  (string)
+    self.assertEqual('""', collapse('"\\\""'))         # "\""   (string)
+    self.assertEqual('""', collapse('"\'"'))           # "'"    (string)
+    self.assertEqual('"\"', collapse('"\"'))           # "\"    (bad)
+    self.assertEqual('""', collapse('"\\\\"'))         # "\\"   (string)
+    self.assertEqual('"', collapse('"\\\\\\"'))        # "\\\"  (bad)
+    self.assertEqual('""', collapse('"\\\\\\\\"'))     # "\\\\" (string)
 
-    self.assertEquals('\'\'', collapse('\'\''))         # ''     (empty)
-    self.assertEquals('\'\'', collapse('\'a\''))        # 'a'    (char)
-    self.assertEquals('\'\'', collapse('\'\\\'\''))     # '\''   (char)
-    self.assertEquals('\'', collapse('\'\\\''))         # '\'    (bad)
-    self.assertEquals('', collapse('\\012'))            # '\012' (char)
-    self.assertEquals('', collapse('\\xfF0'))           # '\xfF0' (char)
-    self.assertEquals('', collapse('\\n'))              # '\n' (char)
-    self.assertEquals(r'\#', collapse('\\#'))           # '\#' (bad)
+    self.assertEqual('\'\'', collapse('\'\''))         # ''     (empty)
+    self.assertEqual('\'\'', collapse('\'a\''))        # 'a'    (char)
+    self.assertEqual('\'\'', collapse('\'\\\'\''))     # '\''   (char)
+    self.assertEqual('\'', collapse('\'\\\''))         # '\'    (bad)
+    self.assertEqual('', collapse('\\012'))            # '\012' (char)
+    self.assertEqual('', collapse('\\xfF0'))           # '\xfF0' (char)
+    self.assertEqual('', collapse('\\n'))              # '\n' (char)
+    self.assertEqual(r'\#', collapse('\\#'))           # '\#' (bad)
 
-    self.assertEquals('"" + ""', collapse('"\'" + "\'"'))
-    self.assertEquals("'', ''", collapse("'\"', '\"'"))
-    self.assertEquals('""[0b10]', collapse('"a\'b"[0b1\'0]'))
+    self.assertEqual('"" + ""', collapse('"\'" + "\'"'))
+    self.assertEqual("'', ''", collapse("'\"', '\"'"))
+    self.assertEqual('""[0b10]', collapse('"a\'b"[0b1\'0]'))
 
-    self.assertEquals('42', collapse("4'2"))
-    self.assertEquals('0b0101', collapse("0b0'1'0'1"))
-    self.assertEquals('1048576', collapse("1'048'576"))
-    self.assertEquals('0X100000', collapse("0X10'0000"))
-    self.assertEquals('0004000000', collapse("0'004'000'000"))
-    self.assertEquals('1.602176565e-19', collapse("1.602'176'565e-19"))
-    self.assertEquals('\'\' + 0xffff', collapse("'i' + 0xf'f'f'f"))
-    self.assertEquals('sizeof\'\' == 1', collapse("sizeof'x' == 1"))
-    self.assertEquals('0x.03p100', collapse('0x.0\'3p1\'0\'0'))
-    self.assertEquals('123.45', collapse('1\'23.4\'5'))
+    self.assertEqual('42', collapse("4'2"))
+    self.assertEqual('0b0101', collapse("0b0'1'0'1"))
+    self.assertEqual('1048576', collapse("1'048'576"))
+    self.assertEqual('0X100000', collapse("0X10'0000"))
+    self.assertEqual('0004000000', collapse("0'004'000'000"))
+    self.assertEqual('1.602176565e-19', collapse("1.602'176'565e-19"))
+    self.assertEqual('\'\' + 0xffff', collapse("'i' + 0xf'f'f'f"))
+    self.assertEqual('sizeof\'\' == 1', collapse("sizeof'x' == 1"))
+    self.assertEqual('0x.03p100', collapse('0x.0\'3p1\'0\'0'))
+    self.assertEqual('123.45', collapse('1\'23.4\'5'))
 
-    self.assertEquals('StringReplace(body, "", "");',
-                      collapse('StringReplace(body, "\\\\", "\\\\\\\\");'))
-    self.assertEquals('\'\' ""',
-                      collapse('\'"\' "foo"'))
+    self.assertEqual('StringReplace(body, "", "");',
+                     collapse('StringReplace(body, "\\\\", "\\\\\\\\");'))
+    self.assertEqual('\'\' ""',
+                     collapse('\'"\' "foo"'))
 
 
 class OrderOfIncludesTest(CpplintTestBase):
@@ -5550,7 +5551,7 @@ class OrderOfIncludesTest(CpplintTestBase):
                      classify_include(file_info('foo/foo.cc'),
                                       'string',
                                       False))
-    self.assertEquals(cpplint._OTHER_HEADER,
+    self.assertEqual(cpplint._OTHER_HEADER,
                      classify_include(file_info('foo/foo.cc'),
                                       'boost/any.hpp',
                                       True))
@@ -5766,8 +5767,8 @@ class CheckForFunctionLengthsTest(CpplintTestBase):
       code: C++ source code expected to generate a warning message.
       expected_message: Message expected to be generated by the C++ code.
     """
-    self.assertEquals(expected_message,
-                      self.PerformFunctionLengthsCheck(code))
+    self.assertEqual(expected_message,
+                     self.PerformFunctionLengthsCheck(code))
 
   def TriggerLines(self, error_level):
     """Return number of lines needed to trigger a function length warning.
@@ -6144,7 +6145,7 @@ class CloseExpressionTest(unittest.TestCase):
                  (18, 47, 20, 1)]
     for p in positions:
       (_, line, column) = cpplint.CloseExpression(self.lines, p[0], p[1])
-      self.assertEquals((p[2], p[3]), (line, column))
+      self.assertEqual((p[2], p[3]), (line, column))
 
   def testReverseCloseExpression(self):
     # List of positions to test:
@@ -6164,7 +6165,7 @@ class CloseExpressionTest(unittest.TestCase):
                  (20, 0, 18, 47)]
     for p in positions:
       (_, line, column) = cpplint.ReverseCloseExpression(self.lines, p[0], p[1])
-      self.assertEquals((p[2], p[3]), (line, column))
+      self.assertEqual((p[2], p[3]), (line, column))
 
 
 class NestingStateTest(unittest.TestCase):
@@ -6181,155 +6182,155 @@ class NestingStateTest(unittest.TestCase):
 
   def testEmpty(self):
     self.UpdateWithLines([])
-    self.assertEquals(self.nesting_state.stack, [])
+    self.assertEqual(self.nesting_state.stack, [])
 
   def testNamespace(self):
     self.UpdateWithLines(['namespace {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0],
                                cpplint._NamespaceInfo))
     self.assertTrue(self.nesting_state.stack[0].seen_open_brace)
-    self.assertEquals(self.nesting_state.stack[0].name, '')
+    self.assertEqual(self.nesting_state.stack[0].name, '')
 
     self.UpdateWithLines(['namespace outer { namespace inner'])
-    self.assertEquals(len(self.nesting_state.stack), 3)
+    self.assertEqual(len(self.nesting_state.stack), 3)
     self.assertTrue(self.nesting_state.stack[0].seen_open_brace)
     self.assertTrue(self.nesting_state.stack[1].seen_open_brace)
     self.assertFalse(self.nesting_state.stack[2].seen_open_brace)
-    self.assertEquals(self.nesting_state.stack[0].name, '')
-    self.assertEquals(self.nesting_state.stack[1].name, 'outer')
-    self.assertEquals(self.nesting_state.stack[2].name, 'inner')
+    self.assertEqual(self.nesting_state.stack[0].name, '')
+    self.assertEqual(self.nesting_state.stack[1].name, 'outer')
+    self.assertEqual(self.nesting_state.stack[2].name, 'inner')
 
     self.UpdateWithLines(['{'])
     self.assertTrue(self.nesting_state.stack[2].seen_open_brace)
 
     self.UpdateWithLines(['}', '}}'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
   def testDecoratedClass(self):
     self.UpdateWithLines(['class Decorated_123 API A {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'A')
+    self.assertEqual(self.nesting_state.stack[0].name, 'A')
     self.assertFalse(self.nesting_state.stack[0].is_derived)
-    self.assertEquals(self.nesting_state.stack[0].class_indent, 0)
+    self.assertEqual(self.nesting_state.stack[0].class_indent, 0)
     self.UpdateWithLines(['}'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
   def testInnerClass(self):
     self.UpdateWithLines(['class A::B::C {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'A::B::C')
+    self.assertEqual(self.nesting_state.stack[0].name, 'A::B::C')
     self.assertFalse(self.nesting_state.stack[0].is_derived)
-    self.assertEquals(self.nesting_state.stack[0].class_indent, 0)
+    self.assertEqual(self.nesting_state.stack[0].class_indent, 0)
     self.UpdateWithLines(['}'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
   def testClass(self):
     self.UpdateWithLines(['class A {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'A')
+    self.assertEqual(self.nesting_state.stack[0].name, 'A')
     self.assertFalse(self.nesting_state.stack[0].is_derived)
-    self.assertEquals(self.nesting_state.stack[0].class_indent, 0)
+    self.assertEqual(self.nesting_state.stack[0].class_indent, 0)
 
     self.UpdateWithLines(['};',
                           'struct B : public A {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'B')
+    self.assertEqual(self.nesting_state.stack[0].name, 'B')
     self.assertTrue(self.nesting_state.stack[0].is_derived)
 
     self.UpdateWithLines(['};',
                           'class C',
                           ': public A {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'C')
+    self.assertEqual(self.nesting_state.stack[0].name, 'C')
     self.assertTrue(self.nesting_state.stack[0].is_derived)
 
     self.UpdateWithLines(['};',
                           'template<T>'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
     self.UpdateWithLines(['class D {', '  class E {'])
-    self.assertEquals(len(self.nesting_state.stack), 2)
+    self.assertEqual(len(self.nesting_state.stack), 2)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'D')
+    self.assertEqual(self.nesting_state.stack[0].name, 'D')
     self.assertFalse(self.nesting_state.stack[0].is_derived)
     self.assertTrue(isinstance(self.nesting_state.stack[1], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[1].name, 'E')
+    self.assertEqual(self.nesting_state.stack[1].name, 'E')
     self.assertFalse(self.nesting_state.stack[1].is_derived)
-    self.assertEquals(self.nesting_state.stack[1].class_indent, 2)
-    self.assertEquals(self.nesting_state.InnermostClass().name, 'E')
+    self.assertEqual(self.nesting_state.stack[1].class_indent, 2)
+    self.assertEqual(self.nesting_state.InnermostClass().name, 'E')
 
     self.UpdateWithLines(['}', '}'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
   def testClassAccess(self):
     self.UpdateWithLines(['class A {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].access, 'private')
+    self.assertEqual(self.nesting_state.stack[0].access, 'private')
 
     self.UpdateWithLines([' public:'])
-    self.assertEquals(self.nesting_state.stack[0].access, 'public')
+    self.assertEqual(self.nesting_state.stack[0].access, 'public')
     self.UpdateWithLines([' protracted:'])
-    self.assertEquals(self.nesting_state.stack[0].access, 'public')
+    self.assertEqual(self.nesting_state.stack[0].access, 'public')
     self.UpdateWithLines([' protected:'])
-    self.assertEquals(self.nesting_state.stack[0].access, 'protected')
+    self.assertEqual(self.nesting_state.stack[0].access, 'protected')
     self.UpdateWithLines([' private:'])
-    self.assertEquals(self.nesting_state.stack[0].access, 'private')
+    self.assertEqual(self.nesting_state.stack[0].access, 'private')
 
     self.UpdateWithLines(['  struct B {'])
-    self.assertEquals(len(self.nesting_state.stack), 2)
+    self.assertEqual(len(self.nesting_state.stack), 2)
     self.assertTrue(isinstance(self.nesting_state.stack[1], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[1].access, 'public')
-    self.assertEquals(self.nesting_state.stack[0].access, 'private')
+    self.assertEqual(self.nesting_state.stack[1].access, 'public')
+    self.assertEqual(self.nesting_state.stack[0].access, 'private')
 
     self.UpdateWithLines(['   protected  :'])
-    self.assertEquals(self.nesting_state.stack[1].access, 'protected')
-    self.assertEquals(self.nesting_state.stack[0].access, 'private')
+    self.assertEqual(self.nesting_state.stack[1].access, 'protected')
+    self.assertEqual(self.nesting_state.stack[0].access, 'private')
 
     self.UpdateWithLines(['  }', '}'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
   def testStruct(self):
     self.UpdateWithLines(['struct A {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'A')
+    self.assertEqual(self.nesting_state.stack[0].name, 'A')
     self.assertFalse(self.nesting_state.stack[0].is_derived)
 
     self.UpdateWithLines(['}',
                           'void Func(struct B arg) {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertFalse(isinstance(self.nesting_state.stack[0],
                                 cpplint._ClassInfo))
 
     self.UpdateWithLines(['}'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
   def testPreprocessor(self):
-    self.assertEquals(len(self.nesting_state.pp_stack), 0)
+    self.assertEqual(len(self.nesting_state.pp_stack), 0)
     self.UpdateWithLines(['#if MACRO1'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 1)
+    self.assertEqual(len(self.nesting_state.pp_stack), 1)
     self.UpdateWithLines(['#endif'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 0)
+    self.assertEqual(len(self.nesting_state.pp_stack), 0)
 
     self.UpdateWithLines(['#ifdef MACRO2'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 1)
+    self.assertEqual(len(self.nesting_state.pp_stack), 1)
     self.UpdateWithLines(['#else'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 1)
+    self.assertEqual(len(self.nesting_state.pp_stack), 1)
     self.UpdateWithLines(['#ifdef MACRO3'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 2)
+    self.assertEqual(len(self.nesting_state.pp_stack), 2)
     self.UpdateWithLines(['#elif MACRO4'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 2)
+    self.assertEqual(len(self.nesting_state.pp_stack), 2)
     self.UpdateWithLines(['#endif'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 1)
+    self.assertEqual(len(self.nesting_state.pp_stack), 1)
     self.UpdateWithLines(['#endif'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 0)
+    self.assertEqual(len(self.nesting_state.pp_stack), 0)
 
     self.UpdateWithLines(['#ifdef MACRO5',
                           'class A {',
@@ -6338,162 +6339,162 @@ class NestingStateTest(unittest.TestCase):
                           '#else',
                           'class C {',
                           '#endif'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 0)
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.pp_stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'A')
+    self.assertEqual(self.nesting_state.stack[0].name, 'A')
     self.UpdateWithLines(['};'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
     self.UpdateWithLines(['class D',
                           '#ifdef MACRO7'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 1)
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.pp_stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'D')
+    self.assertEqual(self.nesting_state.stack[0].name, 'D')
     self.assertFalse(self.nesting_state.stack[0].is_derived)
 
     self.UpdateWithLines(['#elif MACRO8',
                           ': public E'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[0].name, 'D')
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[0].name, 'D')
     self.assertTrue(self.nesting_state.stack[0].is_derived)
     self.assertFalse(self.nesting_state.stack[0].seen_open_brace)
 
     self.UpdateWithLines(['#else',
                           '{'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[0].name, 'D')
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[0].name, 'D')
     self.assertFalse(self.nesting_state.stack[0].is_derived)
     self.assertTrue(self.nesting_state.stack[0].seen_open_brace)
 
     self.UpdateWithLines(['#endif'])
-    self.assertEquals(len(self.nesting_state.pp_stack), 0)
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[0].name, 'D')
+    self.assertEqual(len(self.nesting_state.pp_stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[0].name, 'D')
     self.assertFalse(self.nesting_state.stack[0].is_derived)
     self.assertFalse(self.nesting_state.stack[0].seen_open_brace)
 
     self.UpdateWithLines([';'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
   def testTemplate(self):
     self.UpdateWithLines(['template <T,',
                           '          class Arg1 = tmpl<T> >'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
     self.UpdateWithLines(['class A {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'A')
+    self.assertEqual(self.nesting_state.stack[0].name, 'A')
 
     self.UpdateWithLines(['};',
                           'template <T,',
                           '  template <typename, typename> class B>',
                           'class C'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'C')
+    self.assertEqual(self.nesting_state.stack[0].name, 'C')
     self.UpdateWithLines([';'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
     self.UpdateWithLines(['class D : public Tmpl<E>'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'D')
+    self.assertEqual(self.nesting_state.stack[0].name, 'D')
 
     self.UpdateWithLines(['{', '};'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
     self.UpdateWithLines(['template <class F,',
                           '          class G,',
                           '          class H,',
                           '          typename I>',
                           'static void Func() {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertFalse(isinstance(self.nesting_state.stack[0],
                                 cpplint._ClassInfo))
     self.UpdateWithLines(['}',
                           'template <class J> class K {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'K')
+    self.assertEqual(self.nesting_state.stack[0].name, 'K')
 
   def testTemplateDefaultArg(self):
     self.UpdateWithLines([
       'template <class T, class D = default_delete<T>> class unique_ptr {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(self.nesting_state.stack[0], isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
 
   def testTemplateInnerClass(self):
     self.UpdateWithLines(['class A {',
                           ' public:'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
 
     self.UpdateWithLines(['  template <class B>',
                           '  class C<alloc<B> >',
                           '      : public A {'])
-    self.assertEquals(len(self.nesting_state.stack), 2)
+    self.assertEqual(len(self.nesting_state.stack), 2)
     self.assertTrue(isinstance(self.nesting_state.stack[1], cpplint._ClassInfo))
 
   def testArguments(self):
     self.UpdateWithLines(['class A {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'A')
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 0)
+    self.assertEqual(self.nesting_state.stack[0].name, 'A')
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 0)
 
     self.UpdateWithLines(['  void Func(',
                           '    struct X arg1,'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 1)
     self.UpdateWithLines(['    struct X *arg2);'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 0)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 0)
 
     self.UpdateWithLines(['};'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
     self.UpdateWithLines(['struct B {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
-    self.assertEquals(self.nesting_state.stack[0].name, 'B')
+    self.assertEqual(self.nesting_state.stack[0].name, 'B')
 
     self.UpdateWithLines(['#ifdef MACRO',
                           '  void Func(',
                           '    struct X arg1'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 1)
     self.UpdateWithLines(['#else'])
 
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 0)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 0)
     self.UpdateWithLines(['  void Func(',
                           '    struct X arg1'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 1)
 
     self.UpdateWithLines(['#endif'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 1)
     self.UpdateWithLines(['    struct X *arg2);'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 0)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 0)
 
     self.UpdateWithLines(['};'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
   def testInlineAssembly(self):
     self.UpdateWithLines(['void CopyRow_SSE2(const uint8* src, uint8* dst,',
                           '                  int count) {'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 0)
-    self.assertEquals(self.nesting_state.stack[-1].inline_asm, cpplint._NO_ASM)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 0)
+    self.assertEqual(self.nesting_state.stack[-1].inline_asm, cpplint._NO_ASM)
 
     self.UpdateWithLines(['  asm volatile ('])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 1)
-    self.assertEquals(self.nesting_state.stack[-1].inline_asm,
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 1)
+    self.assertEqual(self.nesting_state.stack[-1].inline_asm,
                       cpplint._INSIDE_ASM)
 
     self.UpdateWithLines(['    "sub        %0,%1                         \\n"',
@@ -6510,40 +6511,40 @@ class NestingStateTest(unittest.TestCase):
                           '    "+r"(count)  // %2',
                           '  :',
                           '  : "memory", "cc"'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 1)
-    self.assertEquals(self.nesting_state.stack[-1].inline_asm,
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 1)
+    self.assertEqual(self.nesting_state.stack[-1].inline_asm,
                       cpplint._INSIDE_ASM)
 
     self.UpdateWithLines(['#if defined(__SSE2__)',
                           '    , "xmm0", "xmm1"'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 1)
-    self.assertEquals(self.nesting_state.stack[-1].inline_asm,
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 1)
+    self.assertEqual(self.nesting_state.stack[-1].inline_asm,
                       cpplint._INSIDE_ASM)
 
     self.UpdateWithLines(['#endif'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 1)
-    self.assertEquals(self.nesting_state.stack[-1].inline_asm,
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 1)
+    self.assertEqual(self.nesting_state.stack[-1].inline_asm,
                       cpplint._INSIDE_ASM)
 
     self.UpdateWithLines(['  );'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 0)
-    self.assertEquals(self.nesting_state.stack[-1].inline_asm, cpplint._END_ASM)
+    self.assertEqual(len(self.nesting_state.stack), 1)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 0)
+    self.assertEqual(self.nesting_state.stack[-1].inline_asm, cpplint._END_ASM)
 
     self.UpdateWithLines(['__asm {'])
-    self.assertEquals(len(self.nesting_state.stack), 2)
-    self.assertEquals(self.nesting_state.stack[-1].open_parentheses, 0)
-    self.assertEquals(self.nesting_state.stack[-1].inline_asm,
+    self.assertEqual(len(self.nesting_state.stack), 2)
+    self.assertEqual(self.nesting_state.stack[-1].open_parentheses, 0)
+    self.assertEqual(self.nesting_state.stack[-1].inline_asm,
                       cpplint._BLOCK_ASM)
 
     self.UpdateWithLines(['}'])
-    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertEqual(len(self.nesting_state.stack), 1)
 
     self.UpdateWithLines(['}'])
-    self.assertEquals(len(self.nesting_state.stack), 0)
+    self.assertEqual(len(self.nesting_state.stack), 0)
 
 
 class QuietTest(unittest.TestCase):
@@ -6580,7 +6581,7 @@ class QuietTest(unittest.TestCase):
   def testNonQuietWithErrors(self):
     # This will fail: the test header is missing a copyright and header guard.
     (return_code, output) = self._runCppLint()
-    self.assertEquals(1, return_code)
+    self.assertEqual(1, return_code)
     # Always-on behavior: Print error messages as they come up.
     self.assertIn("[legal/copyright]", output)
     self.assertIn("[build/header_guard]", output)
@@ -6591,7 +6592,7 @@ class QuietTest(unittest.TestCase):
   def testQuietWithErrors(self):
     # When there are errors, behavior is identical to not passing --quiet.
     (return_code, output) = self._runCppLint('--quiet')
-    self.assertEquals(1, return_code)
+    self.assertEqual(1, return_code)
     self.assertIn("[legal/copyright]", output)
     self.assertIn("[build/header_guard]", output)
     # Even though --quiet was used, print these since there were errors.
@@ -6603,7 +6604,7 @@ class QuietTest(unittest.TestCase):
     (return_code, output) = self._runCppLint('--filter=' +
                                                 '-legal/copyright,' +
                                                 '-build/header_guard')
-    self.assertEquals(0, return_code, output)
+    self.assertEqual(0, return_code, output)
     # No cpplint errors are printed since there were no errors.
     self.assertNotIn("[legal/copyright]", output)
     self.assertNotIn("[build/header_guard]", output)
@@ -6617,7 +6618,7 @@ class QuietTest(unittest.TestCase):
                                              '--filter=' +
                                                  '-legal/copyright,' +
                                                  '-build/header_guard')
-    self.assertEquals(0, return_code, output)
+    self.assertEqual(0, return_code, output)
     # No cpplint errors are printed since there were no errors.
     self.assertNotIn("[legal/copyright]", output)
     self.assertNotIn("[build/header_guard]", output)
@@ -6626,11 +6627,11 @@ class QuietTest(unittest.TestCase):
     self.assertNotIn("Done processing", output)
     self.assertNotIn("Total errors found:", output)
     # Output with no errors must be completely blank!
-    self.assertEquals("", output)
+    self.assertEqual("", output)
 
 # class FileFilterTest(unittest.TestCase):
 #   def testFilterExcludedFiles(self):
-#     self.assertEquals([], _FilterExcludedFiles([]))
+#     self.assertEqual([], _FilterExcludedFiles([]))
 
 # pylint: disable=C6409
 def setUp():

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -673,8 +673,18 @@ class CpplintTest(CpplintTestBase):
                              '// NOLINTEND(*)',
                              ''],
                             error_collector)
-    self.assertEquals('NONLINT block already defined on line 2  '
+    self.assertEqual('NONLINT block already defined on line 2  '
                       '[readability/nolint] [5]', error_collector.Results())
+    # error if NOLINGBEGIN is not ended
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             '// NOLINTBEGIN(readability/casting,runtime/int)',
+                             'long a = (int64) 65;',
+                             'long a = 65;',
+                             ''],
+                            error_collector)
+    self.assertEqual('NONLINT block never ended  [readability/nolint] [5]', error_collector.Results())
     # error if unmatched NOLINTEND
     self.TestLint(
         '// NOLINTEND',


### PR DESCRIPTION
Add support for specifying a NOLINT in a block of code. The
block is started with a NOLINTBEGIN comment which can specify
one or more categories. The block is ended with a NOLINTEND
comment which clears all categories specified in the BEGIN.

Errors are generated if a BEGIN statment occurs in a block, if
END is specified without a BEGIN or if END specifies categories

This is similar to the clang-tidy NOLINTBEGIN/END feature.

https://github.com/google/styleguide/issues/31
https://github.com/cpplint/cpplint/issues/137