### PR TITLE
avoid false positives on transform issue27

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -5962,7 +5962,7 @@ for _header, _templates in _HEADERS_MAYBE_TEMPLATES:
     # Match max<type>(..., ...), max(..., ...), but not foo->max, foo.max or
     # 'type::max()'.
     _re_pattern_headers_maybe_templates.append(
-        (re.compile(r'[^>.]\b' + _template + r'(<.*?>)?\([^\)]'),
+        (re.compile(r'std\b\::' + _template + r'(<.*?>)?\([^\)]'),
             _template,
             _header))
 # Match set<type>, but not foo->set<type>, foo.set<type>

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1030,7 +1030,7 @@ class CpplintTest(CpplintTestBase):
         '  [build/include_what_you_use] [4]')
     self.TestIncludeWhatYouUse(
         """#include "base/foobar.h"
-           bool foobar = min<int>(0,1);
+           bool foobar = std::min<int>(0,1);
         """,
         'Add #include <algorithm> for min  [build/include_what_you_use] [4]')
     self.TestIncludeWhatYouUse(
@@ -1044,18 +1044,23 @@ class CpplintTest(CpplintTestBase):
         '')  # Avoid false positives on strings in other namespaces.
     self.TestIncludeWhatYouUse(
         """#include "base/foobar.h"
-           bool foobar = swap(0,1);
+           bool foobar = std::swap(0,1);
         """,
         'Add #include <utility> for swap  [build/include_what_you_use] [4]')
     self.TestIncludeWhatYouUse(
         """#include "base/foobar.h"
-           bool foobar = transform(a.begin(), a.end(), b.start(), Foo);
+           bool foobar = std::transform(a.begin(), a.end(), b.start(), Foo);
         """,
         'Add #include <algorithm> for transform  '
         '[build/include_what_you_use] [4]')
     self.TestIncludeWhatYouUse(
         """#include "base/foobar.h"
-           bool foobar = min_element(a.begin(), a.end());
+           boost::range::transform(input, std::back_inserter(output), square);
+        """,
+        '') # Avoid false positives on transform in other namespaces.
+    self.TestIncludeWhatYouUse(
+        """#include "base/foobar.h"
+           bool foobar = std::min_element(a.begin(), a.end());
         """,
         'Add #include <algorithm> for min_element  '
         '[build/include_what_you_use] [4]')


### PR DESCRIPTION
This PR addresses https://github.com/cpplint/cpplint/issues/27

I noticed some false positives when using `transform` in other namespaces. There may be some new false negatives when `using namespace std` is used and `std::` is omitted, but it seems worth it.