### PR TITLE
#209 Fix header order confusing warning due to ambiguous "complex.h"

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -408,7 +408,7 @@ _CPP_HEADERS = frozenset([
     'alloc.h',
     'builtinbuf.h',
     'bvector.h',
-    'complex.h',
+    # 'complex.h', collides with System C header "complex.h"
     'defalloc.h',
     'deque.h',
     'editbuf.h',


### PR DESCRIPTION
"complex.h" was both a C99 System header and a old legacy C++ System header. These days, it can be expected that the C header is meant, so cpplint should treat it like that.