### PR TITLE
Add support for multiple categories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   build-test:

--- a/cpplint.py
+++ b/cpplint.py
@@ -5100,7 +5100,7 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
   match = _RE_PATTERN_INCLUDE.search(line)
   if match:
     include = match.group(2)
-    used_angle_brackets = (match.group(1) == '<')
+    used_angle_brackets = match.group(1) == '<'
     duplicate_line = include_state.FindHeader(include)
     if duplicate_line >= 0:
       error(filename, linenum, 'build/include', 4,

--- a/cpplint.py
+++ b/cpplint.py
@@ -98,9 +98,10 @@ Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]
   certain of the problem, and 1 meaning it could be a legitimate construct.
   This will miss some errors, and is not a substitute for a code review.
 
-  To suppress false-positive errors of a certain category, add a
-  'NOLINT(category)' comment to the line.  NOLINT or NOLINT(*)
-  suppresses errors of all categories on that line.
+  To suppress false-positive errors of certain categories, add a
+  'NOLINT(category[, category...])' comment to the line.  NOLINT or NOLINT(*)
+  suppresses errors of all categories on that line. To suppress categories
+  on the next line use NOLINTNEXTLINE instead of NOLINT.
 
   The files passed in will be linted; at least one file must be provided.
   Default linted extensions are %s.
@@ -985,12 +986,11 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
       suppressed_line = linenum + 1
     else:
       suppressed_line = linenum
-    category = matched.group(2)
-    if category in (None, '(*)'):  # => "suppress all"
+    categories = matched.group(2)
+    if categories in (None, '(*)'):  # => "suppress all"
       _error_suppressions.setdefault(None, set()).add(suppressed_line)
-    else:
-      if category.startswith('(') and category.endswith(')'):
-        category = category[1:-1]
+    elif categories.startswith('(') and categories.endswith(')'):
+      for category in set(map(lambda c: c.strip(), categories[1:-1].split(','))):
         if category in _ERROR_CATEGORIES:
           _error_suppressions.setdefault(category, set()).add(suppressed_line)
         elif any(c for c in _OTHER_NOLINT_CATEGORY_PREFIXES if category.startswith(c)):

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -493,6 +493,11 @@ class CpplintTest(CpplintTestBase):
         'long a = (int64) 65;  // NOLINT(runtime/int)',
         'Using C-style cast.  Use static_cast<int64>(...) instead'
         '  [readability/casting] [4]')
+    # Two categories of errors suppressed:
+    self.TestLint(
+        'long a = (int64) 65;  // NOLINT(runtime/int,readability/casting)',
+        '')
+
     # All categories suppressed: (two aliases)
     self.TestLint('long a = (int64) 65;  // NOLINT', '')
     self.TestLint('long a = (int64) 65;  // NOLINT(*)', '')
@@ -514,6 +519,15 @@ class CpplintTest(CpplintTestBase):
                             ['// Copyright 2014 Your Company.',
                              '// NOLINTNEXTLINE(whitespace/line_length)',
                              '//  ./command' + (' -verbose' * 80),
+                             ''],
+                            error_collector)
+    self.assertEquals('', error_collector.Results())
+    # NOLINTNEXTLINE multiple categories silences warning for the next line instead of current line
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             '// NOLINTNEXTLINE(runtime/int,readability/casting)',
+                             'long a = (int64) 65;',
                              ''],
                             error_collector)
     self.assertEquals('', error_collector.Results())


### PR DESCRIPTION
Allow NOLINT and NOLINTNEXTLINE to take a csv of categories to be ignored

Separated PR from https://github.com/cpplint/cpplint/pull/213