### PR TITLE
Avoid false positive on other clang-tidy checks

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -378,7 +378,31 @@ _LEGACY_ERROR_CATEGORIES = [
 # These prefixes for categories should be ignored since they relate to other
 # tools which also use the NOLINT syntax, e.g. clang-tidy.
 _OTHER_NOLINT_CATEGORY_PREFIXES = [
-    'clang-analyzer',
+    'clang-analyzer-',
+    'abseil-',
+    'altera-',
+    'android-',
+    'boost-',
+    'bugprone-',
+    'cert-',
+    'concurrency-',
+    'cppcoreguidelines-',
+    'darwin-',
+    'fuchsia-',
+    'google-',
+    'hicpp-',
+    'linuxkernel-',
+    'llvm-',
+    'llvmlibc-',
+    'misc-',
+    'modernize-',
+    'mpi-',
+    'objc-',
+    'openmp-',
+    'performance-',
+    'portability-',
+    'readability-',
+    'zircon-',
     ]
 
 # The default state of the category filter. This is overridden by the --filter=


### PR DESCRIPTION
This PR allows `cpplint` to avoid false positives on other clang-tidy checks, e.g., `// NOLINTNEXTLINE(readability-magic-numbers)`.

This list is generated with clang-tidy 16 with the following shell oneliner:

```bash
$ clang-tidy --version
LLVM (http://llvm.org/):
  LLVM version 16.0.6
  Optimized build.

$ clang-tidy -checks=*,-clang-analyzer* -list-checks | tail -n+2 | awk '{print $1}' | awk -F'-' '{print $1}' | sort | uniq

abseil
altera
android
boost
bugprone
cert
concurrency
cppcoreguidelines
darwin
fuchsia
google
hicpp
linuxkernel
llvm
llvmlibc
misc
modernize
mpi
objc
openmp
performance
portability
readability
zircon
```

Ref: https://clang.llvm.org/extra/clang-tidy/