### PR TITLE
Handle __VA_OPT__(,)

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -4000,8 +4000,9 @@ def CheckCommaSpacing(filename, clean_lines, linenum, error):
   # verify that lines contain missing whitespaces, second pass on raw
   # lines to confirm that those missing whitespaces are not due to
   # elided comments.
-  if (re.search(r',[^,\s]', re.sub(r'\boperator\s*,\s*\(', 'F(', line)) and
-      re.search(r',[^,\s]', raw[linenum])):
+  match = re.search(r',[^,\s]', re.sub(r'\b__VA_OPT__\s*\(,\)', '',
+                                       re.sub(r'\boperator\s*,\s*\(', 'F(', line)))
+  if (match and re.search(r',[^,\s]', raw[linenum])):
     error(filename, linenum, 'whitespace/comma', 3,
           'Missing space after ,')
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3636,6 +3636,8 @@ class CpplintTest(CpplintTestBase):
     self.TestLint('operator,(a,b)',
                   'Missing space after ,  [whitespace/comma] [3]')
     self.TestLint('__VA_OPT__(,)', '')
+    self.TestLint('__VA_OPT__ (,)',
+                  'Extra space before ( in function call  [whitespace/parens] [4]')
 
   def testEqualsOperatorSpacing(self):
     self.TestLint('int tmp= a;',

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3635,6 +3635,7 @@ class CpplintTest(CpplintTestBase):
     self.TestLint('operator,()', '')
     self.TestLint('operator,(a,b)',
                   'Missing space after ,  [whitespace/comma] [3]')
+    self.TestLint('__VA_OPT__(,)', '')
 
   def testEqualsOperatorSpacing(self):
     self.TestLint('int tmp= a;',


### PR DESCRIPTION
cpplint currently reports code like this:
```cpp
#define myprintf(S, ...) printf(S __VA_OPT__(,) __VA_ARGS__)
```

The rule that's triggering is `whitespace/comma` – it wants a whitespace after the comma inside the `__VA_OPT__`.

Note that the implementation just replaces `\b__VA_OPT__\s*\(,\)` with an empty string when checking the conditions for `whitespace/comma`, but constructs like `__VA_OPT__ (,)` (note the extra space before `(`) are still reported by cpplint – they are caught by `whitespace/parens`.