### PR TITLE
Drop Google repo–priority in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,24 +3,20 @@ Contributing guide
 
 Thanks for your interest in contributing to cpplint.
 
-Any kinds of contributions are welcome: Bug reports, Documentation, Patches.
+Any kinds of contributions are welcome: Bug reports, Documentation, Patches. If you need some ideas, you may check out some of the tasks below:
 
-However, cpplint is a bit special as a project because it aims to closely follow what Google does in the upstream repository.
-That means Google remains the source of all major requirements and functionality of cpplint whereas this fork adds extensions to cpplint run on more environments and in more companies.
-The difference between this cpplint and Google should remain so small that anyone can at a glance see there is no added change that could be regarded as a security vulnerability.
+* Reducing interference with other popular tools
+* Update cpplint for modern python versions
+  * Converting setup.py to a pyproject.toml
+* Porting cpplint to other environments
+  * Making tests, especially clitest, work on Windows
+* Complete tickets in our `issue tracker <https://github.com/cpplint/cpplint/issues>`_
 
-Please consider our goals and non-goals below before contributing.
+Discouraged changes:
 
-Goals:
-
-* Provides cpplint as a PyPI package for multiple python versions
-* Add features and fixes aimed at usages outside Google
-
-Non-Goals:
-
-* Become an independent fork adding major features
-* Fix python style issues in cpplint (PRs welcome, but not recommended)
-
+* Drastic reorganization
+  * Making the code conform to Google's Python style guidelines
+* Features that could be regarded as a security vulnerability
 
 Development
 -----------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,20 +3,13 @@ Contributing guide
 
 Thanks for your interest in contributing to cpplint.
 
-Any kinds of contributions are welcome: Bug reports, Documentation, Patches. If you need some ideas, you may check out some of the tasks below:
-
-* Reducing interference with other popular tools
-* Update cpplint for modern python versions
-  * Converting setup.py to a pyproject.toml
-* Porting cpplint to other environments
-  * Making tests, especially clitest, work on Windows
-* Complete tickets in our `issue tracker <https://github.com/cpplint/cpplint/issues>`_
-
-Here are some contributions you probably shouldn't make:
+Any kinds of contributions are welcome: Bug reports, Documentation, Patches. However, here are some contributions you probably shouldn't make:
 
 * Drastic reorganization
   * Making the code conform to Google's Python style guidelines
 * Features that could be regarded as a security vulnerability
+
+If you need some ideas, you may check out some of the tasks in our `issue tracker <https://github.com/cpplint/cpplint/issues>`_.
 
 Development
 -----------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,7 +12,7 @@ Any kinds of contributions are welcome: Bug reports, Documentation, Patches. If 
   * Making tests, especially clitest, work on Windows
 * Complete tickets in our `issue tracker <https://github.com/cpplint/cpplint/issues>`_
 
-Discouraged changes:
+Here are some contributions you probably shouldn't make:
 
 * Drastic reorganization
   * Making the code conform to Google's Python style guidelines

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,11 @@ cpplint - static code checker for C++
 .. image:: https://img.shields.io/pypi/dm/cpplint.svg
     :target: https://pypi.python.org/pypi/cpplint
 
-Cpplint is a command-line tool to check C/C++ files for style issues following `Google's C++ style guide <http://google.github.io/styleguide/cppguide.html>`_.
-Cpplint is developed and maintained by Google Inc. at `google/styleguide <https://github.com/google/styleguide>`_, also see the `wikipedia entry <http://en.wikipedia.org/wiki/Cpplint>`_
+Cpplint is a command-line tool to check C/C++ files for style issues according to `Google's C++ style guide <http://google.github.io/styleguide/cppguide.html>`_.
 
-While Google maintains cpplint, Google is not (very) responsive to issues and pull requests, this fork aims to be (somewhat) more open to add fixes to cpplint to enable fixes, when those fixes make cpplint usable in wider contexts.
-Also see discussion here https://github.com/google/styleguide/pull/528.
+Cpplint used to be developed and maintained by Google Inc. at `google/styleguide <https://github.com/google/styleguide>`_. Nowadays, `Google is no longer maintaining the public version of cpplint <https://github.com/google/styleguide/pull/528#issuecomment-592315430>`_, and pretty much everything in their repo's PRs and issues about cpplint have gone unimplemented.
+
+This fork aims to update cpplint to modern specifications, and be (somewhat) more open to adding fixes and features to make cpplint usable in wider contexts.
 
 
 Installation
@@ -54,8 +54,6 @@ For full usage instructions, run:
 Changes
 -------
 
-The modifications in this fork are minor fixes and cosmetic changes, such as:
-
 * python 3 compatibility
 * more default file extensions
 * customizable file extensions with the --extensions argument
@@ -65,7 +63,7 @@ The modifications in this fork are minor fixes and cosmetic changes, such as:
 * JUnit XML output format
 * Overriding repository root auto-detection via --repository
 * Support ``#pragma once`` as an alternative to header include guards
-* ... and a few more (most of which are open PRs on upstream)
+* ... and `quite a bit <https://github.com/cpplint/cpplint/blob/master/changelog.rst>`_ more
 
 
 Acknowledgements


### PR DESCRIPTION
See https://github.com/google/styleguide/pull/528#issuecomment-592315430. Google is no longer maintaining the public version of cpplint, and pretty much everything in their repo's PRs and issues about cpplint have gone unimplemented. Thus, recommending people do stuff there first is sort of useless, and there's not much use confining ourselves to Google's feature set.

I have replaced it with something that's sort of a to-do list + a list of things that probably shouldn't be done.

This may not be needed if the promised publishing of Google's internal version arrives.

Note that I didn't mean to say "Google-favoring" in a derogatory way. Better wording suggestions are welcome.

(When merging, please squash and merge)