### PR TITLE
Re-add tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py37, py312, pypy3
+envlist = py37, py38, py39, py311, py312, pypy3
+skip_missing_interpreters = true
 
 [gh-actions]
 python =
@@ -22,6 +23,6 @@ deps =
   setuptools==58.2.0
 
 commands =
-  {envpython} -m pytest
+  {envpython} -m pytest {posargs:}
   {envpython} -m pylint cpplint.py
   {envpython} -m flake8


### PR DESCRIPTION
These were removed in https://github.com/cpplint/cpplint/commit/be2a415b364872cee5fe5e568c77a7959de07953

These are necessary to *allow* testing on those Python versions.  They do not cause CI to test them all.