### PR TITLE
Use timeout instead of verbose pytest output

### DIFF
--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -39,6 +39,7 @@ import subprocess
 import unittest
 import shutil
 import tempfile
+import pytest
 
 from testfixtures import compare
 
@@ -196,6 +197,7 @@ class NoRepoSignatureTests(TemporaryFolderClassSetup, unittest.TestCase):
     def testBoostSample(self):
         self.checkAllInFolder('./samples/boost-sample', 4)
 
+    @pytest.mark.timeout(180)
     def testProtobufSample(self):
         self.checkAllInFolder('./samples/protobuf-sample', 1)
 

--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -39,8 +39,7 @@ import subprocess
 import unittest
 import shutil
 import tempfile
-import pytest
-
+from pytest import mark
 from testfixtures import compare
 
 BASE_CMD = sys.executable + ' ' + os.path.abspath('./cpplint.py ')
@@ -197,7 +196,7 @@ class NoRepoSignatureTests(TemporaryFolderClassSetup, unittest.TestCase):
     def testBoostSample(self):
         self.checkAllInFolder('./samples/boost-sample', 4)
 
-    @pytest.mark.timeout(180)
+    @mark.timeout(180)
     def testProtobufSample(self):
         self.checkAllInFolder('./samples/protobuf-sample', 1)
 

--- a/dev-requirements
+++ b/dev-requirements
@@ -1,7 +1,5 @@
 # requirements to run development steps
 
-# also change in tox.ini
 flake8>=4.0.1
 pylint>=2.11.0
-importlib-metadata>=0.12
 setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,7 @@ test = pytest
 [tool:pytest]
 python_files = *test.py
 testpaths = .
+required_plugins = pytest-cov pytest-timeout
+timeout = 64
 # running with tox reports only 75%
-addopts = --cov-fail-under=75 --cov=cpplint --color=yes
+addopts = --color=yes --cov-fail-under=75 --cov=cpplint

--- a/test-requirements
+++ b/test-requirements
@@ -1,7 +1,7 @@
 # requirements for testing steps
 tox<5.0.0
 
-# also change in tox.ini
 pytest
 pytest-cov
+pytest-timeout
 testfixtures

--- a/tox.ini
+++ b/tox.ini
@@ -12,17 +12,9 @@ python =
     pypy3.10: pypy3
 
 [testenv]
-deps =
-  flake8>=4.0.1
-  radon>=2.4.0
-  pylint>=2.11.0
-  flake8-polyfill
-  pytest
-  pytest-cov
-  testfixtures
-  setuptools
+extras = dev
 
 commands =
-  {envpython} -m pytest -v {posargs:}
+  {envpython} -m pytest {posargs:}
   {envpython} -m pylint cpplint.py
-  {envpython} -m flake8
+  {envpython} -m flake8 cpplint.py


### PR DESCRIPTION
The verbose pytest output is quite annoying to read in a CI, and using a timeout solves the issue of knowing which tests hang.

Also included: tox.ini now installs the extra [dev], so we only need to make changes in one place now.