### PR TITLE
Don't run ci on push if not on main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     paths-ignore: "*.rst"
+    branches: [master, develop]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Before this, every pull request would run checks on its latest commit twice, which is sort of a waste of resources