### PR TITLE
Clarify installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,12 @@ To install cpplint from PyPI, run:
 
     $ pip install cpplint
 
-Then run it with:
+Externally managed environments
+-------------------------------
+If you get the "This environment is externally managed" error, try to search and install cpplint with your system's package manager (e.g. apt, rpm, pacman...). If it doesn't exist, you can either package cpplint for your distribution or repeat the steps above with the :code:`--break-system-packages` flag.
 
+Usage
+-----
 .. code-block:: bash
 
     $ cpplint [OPTIONS] files


### PR DESCRIPTION
Move usage to its own section and provide rudimentary instructions to defuse error caused by external package managers