### PR TITLE
Avoid IWYU False Positives on external libraries

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -5941,7 +5941,7 @@ for _header, _templates in _HEADERS_MAYBE_TEMPLATES:
     # Match max<type>(..., ...), max(..., ...), but not foo->max, foo.max or
     # 'type::max()'.
     _re_pattern_headers_maybe_templates.append(
-        (re.compile(r'[^>.]\b' + _template + r'(<.*?>)?\([^\)]'),
+        (re.compile(r'((\bstd::)|[^>.:])\b' + _template + r'(<.*?>)?\([^\)]'),
             _template,
             _header))
 # Match set<type>, but not foo->set<type>, foo.set<type>

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1052,7 +1052,12 @@ class CpplintTest(CpplintTestBase):
         '[build/include_what_you_use] [4]')
     self.TestIncludeWhatYouUse(
         """#include "base/foobar.h"
-           bool foobar = min_element(a.begin(), a.end());
+           boost::range::transform(input, std::back_inserter(output), square);
+        """,
+        '') # Avoid false positives on transform in other namespaces.
+    self.TestIncludeWhatYouUse(
+        """#include "base/foobar.h"
+           bool foobar = std::min_element(a.begin(), a.end());
         """,
         'Add #include <algorithm> for min_element  '
         '[build/include_what_you_use] [4]')


### PR DESCRIPTION
Follow-up to https://github.com/cpplint/cpplint/pull/217

Here is another try at addressing https://github.com/cpplint/cpplint/issues/27. Instead of only checking against the qualified call (i.e. `std::`), it also checks against the unqualified call. This change should preserve backward compatibility while preventing false positives for common names in other namespaces.

## Here is a quick list of checks
### These emit warnings
`std::make_pair(1, 2)`
`   std::make_pair(1, 2)`
`make_pair(1, 2)`
`auto foo = std::make_pair(1, 2)`

### These do not emit warnings
`boost::make_pair(1, 2)`
`asdfasdf::make_pair(1, 2)`
`asdfasdfstd::make_pair(1, 2)`
`.make_pair(1, 2)`