### PR TITLE
Remove IWYU False Positives From Other Namespaces

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -6019,7 +6019,7 @@ _HEADERS_CONTAINING_TEMPLATES = (
     ('<memory>', ('allocator', 'make_shared', 'make_unique', 'shared_ptr',
                   'unique_ptr', 'weak_ptr')),
     ('<queue>', ('queue', 'priority_queue',)),
-    ('<set>', ('multiset',)),
+    ('<set>', ('set', 'multiset',)),
     ('<stack>', ('stack',)),
     ('<string>', ('char_traits', 'basic_string',)),
     ('<tuple>', ('tuple',)),
@@ -6072,12 +6072,9 @@ for _header, _templates in _HEADERS_MAYBE_TEMPLATES:
         (re.compile(r'((\bstd::)|[^>.:])\b' + _template + r'(<.*?>)?\([^\)]'),
             _template,
             _header))
-# Match set<type>, but not foo->set<type>, foo.set<type>
-_re_pattern_headers_maybe_templates.append(
-    (re.compile(r'[^>.]\bset\s*\<'),
-        'set<>',
-        '<set>'))
-# Match 'map<type> var' and 'std::map<type>(...)', but not 'map<type>(...)''
+
+# Map is often overloaded. Only check, if it is fully qualified.
+# Match 'std::map<type>(...)', but not 'map<type>(...)''
 _re_pattern_headers_maybe_templates.append(
     (re.compile(r'(std\b::\bmap\s*\<)|(^(std\b::\b)map\b\(\s*\<)'),
         'map<>',
@@ -6088,7 +6085,7 @@ _re_pattern_templates = []
 for _header, _templates in _HEADERS_CONTAINING_TEMPLATES:
   for _template in _templates:
     _re_pattern_templates.append(
-        (re.compile(r'(\<|\b)' + _template + r'\s*\<'),
+        (re.compile(r'((^|(^|\s|((^|\W)::))std::)|[^>.:]\b)' + _template + r'\s*\<'),
          _template + '<>',
          _header))
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1249,6 +1249,12 @@ class CpplintTest(CpplintTestBase):
         auto res = map<Bar>();
         """,
         '')
+    # False positive for boost::container::set
+    self.TestIncludeWhatYouUse(
+        """
+        boost::container::set<int> foo;
+        """,
+        '')
 
   def testFilesBelongToSameModule(self):
     f = cpplint.FilesBelongToSameModule


### PR DESCRIPTION
This PR removes the false positives from `_HEADERS_CONTAINING_TEMPLATES` that come from non `std` namespaces. Users of boost or other namespaces will no longer get false positives.

```c++
// Warn
set<int> blah1;
std::set<int> blah2;
::std::set<int> blah2;
  set<int> blah1;
  std::set<int> blah2;
  ::std::set<int> blah2;

//  NO WARN
foo.set<int>();
foo->set<int>();

boost::container::set<int> blah3;
blah::std::set<int> blah3;
my_std::set<int> blah3;
my_set<int> blah4;
coolset<int> blah5;
std::blah<int> blah6;
::set<int> blah7;
```