### PR TITLE
Add build/namespaces_names error

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -307,6 +307,7 @@ _ERROR_CATEGORIES = [
     'build/include_what_you_use',
     'build/namespaces_headers',
     'build/namespaces_literals',
+    'build/namespaces_names',
     'build/namespaces',
     'build/printf_format',
     'build/storage_class',
@@ -5483,6 +5484,19 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
           'Do not use unnamed namespaces in header files.  See '
           'https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces'
           ' for more information.')
+
+  # Check namespace names for correct naming, according to
+  # https://google.github.io/styleguide/cppguide.html#Namespace_Names
+  # namespace names are "all lower-case, with words separated by underscores"
+  match = re.match(r'.*namespace\s+([^{=;]+)\s+[{;=]', line)
+  if match:
+    name = match.group(1)
+    if name != "" and not re.match(r'^((inline )?[a-z_]+(::)?)+$', name):
+      error(filename, linenum, 'build/namespaces_names', 4,
+            'Namespace names must be all lower-case, with words separated '
+            'by underscores. See '
+            'https://google.github.io/styleguide/cppguide.html#Namespace_Names'
+            ' for more information.')
 
 
 def CheckGlobalStatic(filename, clean_lines, linenum, error):

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4578,6 +4578,34 @@ class CpplintTest(CpplintTestBase):
       self.TestLanguageRulesCheck('foo.' + extension, 'namespace {', '')
       self.TestLanguageRulesCheck('foo.' + extension, 'namespace foo {', '')
 
+  def testNamespaceNames(self):
+    for extension in ['h', 'hpp', 'hxx', 'h++', 'cuh']:
+      self.TestLanguageRulesCheck(
+        'foo.' + extension, 'namespace CamelCase {}',
+        'Namespace names must be all lower-case, with words separated by underscores. '
+        'See https://google.github.io/styleguide/cppguide.html#Namespace_Names '
+        'for more information.  [build/namespaces_names] [4]')
+      self.TestLanguageRulesCheck(
+        'foo.' + extension, 'inline namespace Uppercase {',
+        'Namespace names must be all lower-case, with words separated by underscores. '
+        'See https://google.github.io/styleguide/cppguide.html#Namespace_Names '
+        'for more information.  [build/namespaces_names] [4]')
+      self.TestLanguageRulesCheck(
+        'foo.' + extension, 'namespace Uppercase = std',
+        'Namespace names must be all lower-case, with words separated by underscores. '
+        'See https://google.github.io/styleguide/cppguide.html#Namespace_Names '
+        'for more information.  [build/namespaces_names] [4]')
+      self.TestLanguageRulesCheck(
+        'foo.' + extension, 'namespace a::inline b::inline C {',
+        'Namespace names must be all lower-case, with words separated by underscores. '
+        'See https://google.github.io/styleguide/cppguide.html#Namespace_Names '
+        'for more information.  [build/namespaces_names] [4]')
+      self.TestLanguageRulesCheck('foo.' + extension, 'namespace lower_case {}', '')
+      self.TestLanguageRulesCheck('foo.' + extension, 'namespace a::b::c {}', '')
+      self.TestLanguageRulesCheck('foo.' + extension, 'namespace a::b::inline c {}', '')
+      self.TestLanguageRulesCheck('foo.' + extension, 'namespace lower_case = Uppercase', '')
+      self.TestLanguageRulesCheck('foo.' + extension, 'inline namespace a::inline b {}}', '')
+
   def testBuildClass(self):
     # Test that the linter can parse to the end of class definitions,
     # and that it will report when it can't.

--- a/samples/v8-sample/simple.def
+++ b/samples/v8-sample/simple.def
@@ -2,8 +2,9 @@ src/*
 1
 3
 Done processing src/interface-descriptors.h
-Total errors found: 2
+Total errors found: 3
 
 src/interface-descriptors.h:5:  #ifndef header guard has wrong style, please use: SAMPLES_V8_SAMPLE_SRC_INTERFACE_DESCRIPTORS_H_  [build/header_guard] [5]
 src/interface-descriptors.h:1255:  #endif line should be "#endif  // SAMPLES_V8_SAMPLE_SRC_INTERFACE_DESCRIPTORS_H_"  [build/header_guard] [5]
+src/interface-descriptors.h:15:  Namespace names must be all lower-case, with words separated by underscores. See https://google.github.io/styleguide/cppguide.html#Namespace_Names for more information.  [build/namespaces_names] [4]
 


### PR DESCRIPTION
This error category checks whether all namespace names are written in lowercase, with words separated by underscores, as is recommended by the google style guide:
https://google.github.io/styleguide/cppguide.html#Namespace_Names

This is accomplished by checking every line against a regular expression to find namespace declarations first, and afterwards check the name of that namespace.

The `v8` sample fails this check, as it defines a namespace `v8`, which is not allowed. Subsequently, I also changed that test definition.