### PR TITLE
Fix false positive on concept declaration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ A bunch of long-overdue modernizations of the codebase!
 * Indented functions inside namespaces will now be correctly erred on, courtesy of @Yujinmon (https://github.com/cpplint/cpplint/pull/235)
 * The check for C-style casts now looks for the standard fixed-width integer typenames instead of non-standard ones (e.g. int32_t instead of int32) thanks to @nate-thirdwave (https://github.com/cpplint/cpplint/pull/282)
 * `[[(un)likely]]` no longer clouds readability/braces's super spy−scanning of braces, courtesy of @aaronliu0130 (https://github.com/cpplint/cpplint/pull/265)
+* `readability/braces` will realize that C++20 concepts require a semicolon, courtesy of @armandas (https://github.com/cpplint/cpplint/pull/288)
 * C++20 headers will no longer be flagged as C headers thanks to @miker2 (https://github.com/cpplint/cpplint/pull/216)
    * Same goes for C++23 and C23 headers, thanks to @aaronliu0130 (https://github.com/cpplint/cpplint/pull/239)
    * "complex.h" will be treated as the C99 header instead of the legacy C++ header by @tkruse (https://github.com/cpplint/cpplint/pull/219)

--- a/cpplint.py
+++ b/cpplint.py
@@ -4539,6 +4539,7 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
     #  - Lambdas
     #  - alignas specifier with anonymous structs
     #  - decltype
+    #  - concepts (requires expression)
     closing_brace_pos = match.group(1).rfind(')')
     opening_parenthesis = ReverseCloseExpression(
         clean_lines, linenum, closing_brace_pos)
@@ -4554,6 +4555,7 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
           (func and not re.search(r'\boperator\s*\[\s*\]', func.group(1))) or
           re.search(r'\b(?:struct|union)\s+alignas\s*$', line_prefix) or
           re.search(r'\bdecltype$', line_prefix) or
+          re.search(r'\brequires.*$', line_prefix) or
           re.search(r'\s+=\s*$', line_prefix)):
         match = None
     if (match and

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -2807,6 +2807,21 @@ class CpplintTest(CpplintTestBase):
 
     self.TestLint('file_tocs_[i] = (FileToc) {a, b, c};', '')
     self.TestMultiLineLint('class X : public Y,\npublic Z {};', '')
+    self.TestMultiLineLint('template<typename T>\n'
+                           'concept Addable = requires(T x) { x + x; };',
+                           '')
+    self.TestMultiLineLint('template <typename T>\n'
+                           'concept C = requires(T a, T b) {\n'
+                           '    requires a == b;\n'
+                           '};',
+                           '')
+    self.TestMultiLineLint('template <typename T, typename U>\n'
+                           'concept C = (std::integral<T> || std::floating_point<T>) &&\n'
+                           '            (std::integral<U> || std::floating_point<U>) &&\n'
+                           '            requires(T t, U u) {\n'
+                           '    std::min(static_cast<float>(t), static_cast<float>(u));\n'
+                           '};',
+                           '')
 
   def testSpacingBeforeBrackets(self):
     self.TestLint('int numbers [] = { 1, 2, 3 };',


### PR DESCRIPTION
My attempt to fix #225, since #229 seems to be dead.

I used a `requires` keyword for concept detection, as the `concept` keyword could be a few lines above the opening brace.
Not 100% on the regex, so if someone could check it, I would appreciate it.