### PR TITLE
Disable "too-many-positional-arguments"

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,8 @@ disable=
   useless-object-inheritance,
   consider-using-dict-comprehension,
   consider-using-in,
-  unnecessary-pass
+  unnecessary-pass,
+  too-many-positional-arguments
 
 [REPORTS]
 output-format=colorized


### PR DESCRIPTION
This is fine for our repo and leads to many innocent PRs being flagged down by Pylint 3.3.0