### PR TITLE
supress C++-only categories on C file extensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@ Changelog
 
 Yet another overdue... hotfix. Sorry this took so long.
 
-* The false positive for indented function parameters in namespaces was eradicated.
+* The false positive for indented function parameters in namespaces was eradicated. (https://github.com/cpplint/cpplint/pull/304)
+* Files that end in ".c", ".C", or ".cu" will now also automatically suppress C++-only categories. Previously, `// NO_LINT_C` was required. (https://github.com/cpplint/cpplint/pull/308)
 
 2.0 (2024-10-06)
 ================

--- a/cpplint.py
+++ b/cpplint.py
@@ -1111,21 +1111,18 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
           error(filename, linenum, 'readability/nolint', 5,
                 f'Unknown NOLINT error category: {category}')
 
-def ProcessGlobalSuppresions(lines):
-  """Deprecated; use ProcessGlobalSuppressions."""
-  ProcessGlobalSuppressions(lines)
-
-def ProcessGlobalSuppressions(lines):
+def ProcessGlobalSuppressions(filename, lines):
   """Updates the list of global error suppressions.
 
   Parses any lint directives in the file that have global effect.
 
   Args:
+    filename: str, the name of the input file.
     lines: An array of strings, each representing a line of the file, with the
            last element being empty if the file is terminated with a newline.
   """
   for line in lines:
-    if _SEARCH_C_FILE.search(line):
+    if _SEARCH_C_FILE.search(line) or filename.endswith(('.c', '.cu', '.C')):
       for category in _DEFAULT_C_SUPPRESSED_CATEGORIES:
         _error_suppressions.AddGlobalSuppression(category)
     if _SEARCH_KERNEL_FILE.search(line):
@@ -6522,7 +6519,7 @@ def ProcessFileData(filename, file_extension, lines, error,
   ResetNolintSuppressions()
 
   CheckForCopyright(filename, lines, error)
-  ProcessGlobalSuppressions(lines)
+  ProcessGlobalSuppressions(filename, lines)
   RemoveMultiLineComments(filename, lines, error)
   clean_lines = CleansedLines(lines)
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -477,10 +477,18 @@ class CpplintTest(CpplintTestBase):
     self.TestLint(
         'long a = (int64_t) 65;  // NOLINT(runtime/int,readability/casting)',
         '')
-
     # All categories suppressed: (two aliases)
     self.TestLint('long a = (int64_t) 65;  // NOLINT', '')
     self.TestLint('long a = (int64_t) 65;  // NOLINT(*)', '')
+    # Linting a C file
+    error_collector = ErrorCollector(self.assertTrue)
+    cpplint.ProcessFileData('test.c', 'c',
+                            ['// Copyright 2014 Your Majesty.',
+                             'int64_t a = (int64_t) 65;',
+                             ''],
+                            error_collector)
+    self.assertEqual('', error_collector.Results())
+
     # Malformed NOLINT directive:
     self.TestLint(
         'long a = 65;  // NOLINT(foo)',

--- a/samples/vlc-sample/simple.def
+++ b/samples/vlc-sample/simple.def
@@ -4,7 +4,7 @@ src/*
 Done processing src/libvlc.c
 Done processing src/libvlc.h
 Done processing src/missing.c
-Total errors found: 602
+Total errors found: 600
 
 src/libvlc.c:41:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:47:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
@@ -19,7 +19,6 @@ src/libvlc.c:86:  Extra space before ( in function call  [whitespace/parens] [4]
 src/libvlc.c:86:  Extra space before )  [whitespace/parens] [2]
 src/libvlc.c:92:  Extra space after ( in function call  [whitespace/parens] [4]
 src/libvlc.c:93:  { should almost always be at the end of the previous line  [whitespace/braces] [4]
-src/libvlc.c:98:  Using C-style cast.  Use reinterpret_cast<vlc_object_t *>(...) instead  [readability/casting] [4]
 src/libvlc.c:99:  Extra space before )  [whitespace/parens] [2]
 src/libvlc.c:100:  Missing space before ( in if(  [whitespace/parens] [5]
 src/libvlc.c:103:  Extra space before ( in function call  [whitespace/parens] [4]
@@ -74,7 +73,6 @@ src/libvlc.c:219:  Extra space before )  [whitespace/parens] [2]
 src/libvlc.c:220:  Missing space before ( in if(  [whitespace/parens] [5]
 src/libvlc.c:221:  { should almost always be at the end of the previous line  [whitespace/braces] [4]
 src/libvlc.c:222:  Extra space after ( in function call  [whitespace/parens] [4]
-src/libvlc.c:222:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
 src/libvlc.c:223:  Extra space after ( in function call  [whitespace/parens] [4]
 src/libvlc.c:223:  Extra space before )  [whitespace/parens] [2]
 src/libvlc.c:224:  Extra space after ( in function call  [whitespace/parens] [4]


### PR DESCRIPTION
".h" files don't, because many C++ headers also use this extension

Closes #71 