### PR TITLE
workflow and automation cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,29 +11,43 @@ concurrency:
 jobs:
   build-test:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+      PYTHONIOENCODING: utf-8
+      PIP_DOWNLOAD_CACHE: ${{ github.workspace }}/../.pip_download_cache
     strategy:
-      matrix:
-        # Python 3.8 is the last non-EOL version. Also adapt tox.ini
-        python-version: ['3.8', 'pypy3.10', '3.12']
-        os: [ubuntu-latest, windows-latest]
       fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-latest, windows-latest]
+        python-version: [3.9, '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
+          allow-prereleases: true
           cache: 'pip'
           cache-dependency-path: '**/test-requirements'
+        env:
+          SETUPTOOLS_USE_DISTUTILS: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.9' && 'stdlib' || 'local' }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
-          python -m pip install 'tox-gh-actions<4.0.0'
+          pip install tox tox-gh-actions
+
       - name: Test with tox
-        run: tox
+        run: |
+          tox
+        env:
+          PLATFORM: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [macos-15, macos-latest, ubuntu-latest, ubuntu-22.04, ubuntu-24.04-arm, windows-latest, windows-2025]
         python-version: [3.9, '3.10', '3.11', '3.12']
 
     steps:
@@ -39,7 +39,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/test-requirements'
         env:
-          SETUPTOOLS_USE_DISTUTILS: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.9' && 'stdlib' || 'local' }}
+          SETUPTOOLS_USE_DISTUTILS: ${{ startsWith(matrix.os, 'macos') || matrix.os == 'ubuntu-24.04-arm' && matrix.python-version == '3.9' && 'stdlib' || 'local' }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  push:
+    # release on tag push
+    tags:
+      - '*'
+
+jobs:
+  wheels:
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PYTHONIOENCODING: utf-8
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.9, '3.10', '3.11', '3.12']
+
+    steps:
+    - name: Set git crlf/eol
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+        cache: 'pip'
+        cache-dependency-path: '**/test-requirements'
+      env:
+        SETUPTOOLS_USE_DISTUTILS: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.9' && 'stdlib' || 'local' }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install tox tox-gh-actions
+
+    - name: Build dist pkgs
+      run: |
+        tox -e build
+
+    - name: Upload artifacts
+      if: matrix.python-version == 3.9 && runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: dist
+
+  create_release:
+    name: Create Release
+    needs: [wheels]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Get version
+        id: get_version
+        run: |
+          echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo ${{ env.VERSION }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # download all artifacts to project dir
+      - uses: actions/download-artifact@v4
+
+      - name: Generate changes file
+        uses: sarnold/gitchangelog-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN}}
+
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          name: Release v${{ env.VERSION }}
+          body_path: CHANGES.md
+          draft: false
+          prerelease: false
+          files: |
+            packages/cpplint*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-15, macos-latest, ubuntu-latest, ubuntu-22.04, ubuntu-24.04-arm, windows-latest, windows-2025]
         python-version: [3.9, '3.10', '3.11', '3.12']
 
     steps:
@@ -44,11 +44,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        pip install tox tox-gh-actions
+        pip install tox
 
     - name: Build dist pkgs
       run: |
-        tox -e build
+        tox -e build,check
 
     - name: Upload artifacts
       if: matrix.python-version == 3.9 && runner.os == 'Linux'
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/download-artifact@v4
 
       - name: Generate changes file
-        uses: sarnold/gitchangelog-action@master
+        uses: sarnold/gitchangelog-action@915234f151ceffb7a8c4f76de77e4ae321087b8f  # 1.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN}}
 
@@ -94,3 +94,24 @@ jobs:
           prerelease: false
           files: |
             packages/cpplint*
+
+  # When a GitHub release is made, upload the artifacts to PyPI
+  upload:
+    name: Upload to PyPI
+    runs-on: ubuntu-22.04
+    needs: [wheels]
+
+    steps:
+    - uses: actions/setup-python@v5
+
+    - uses: actions/download-artifact@v4
+
+    - name: check artifacts
+      run: find packages/ -maxdepth 2 -name cpplint-\* -type f
+
+#    - name: Publish bdist and sdist packages
+#      uses: pypa/gh-action-pypi-publish@release/v1
+#      with:
+#        password: ${{ secrets.PYPI_API_TOKEN }}
+#        packages_dir: packages/
+#        print_hash: true

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ def read_without_comments(filename):
     with open(filename) as f:
         return [line for line in f.read().splitlines() if not len(line) == 0 and not line.startswith('#')]
 
-test_required = read_without_comments('test-requirements')
 
 setup(name='cpplint',
       version=cpplint.__VERSION__,
@@ -30,19 +29,19 @@ setup(name='cpplint',
                    'License :: OSI Approved :: BSD License',
                    'Natural Language :: English',
                    'Programming Language :: Python :: 3 :: Only',
-                   'Programming Language :: Python :: 3.8',
                    'Programming Language :: Python :: 3.9',
                    'Programming Language :: Python :: 3.10',
                    'Programming Language :: Python :: 3.11',
                    'Programming Language :: Python :: 3.12',
+                   'Programming Language :: Python :: 3.13',
                    'Programming Language :: C++',
                    'Topic :: Software Development :: Quality Assurance'],
       description='Automated checker to ensure C++ files follow Google\'s style guide',
       long_description=open('README.rst').read(),
+      long_description_content_type='text/x-rst',
       license='BSD-3-Clause',
-      tests_require=test_required,
       # extras_require allow pip install .[dev]
       extras_require={
-          'test': test_required,
-          'dev': read_without_comments('dev-requirements') + test_required
+          'test': read_without_comments('test-requirements'),
+          'dev': read_without_comments('dev-requirements'),
       })

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,97 @@
 [tox]
-envlist = py38, py39, py3.10, py311, py312, pypy3
+envlist = pypy3,py3{8,9,10,11,12,13}-{linux,macos,windows}
 skip_missing_interpreters = true
+isolated_build = true
+skipsdist = true
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
-    pypy3.10: pypy3
+    3.13: py313
+
+[gh-actions:env]
+PLATFORM =
+    ubuntu-latest: linux
+    ubuntu-22.04: linux
+    macos-latest: macos
+    windows-latest: windows
 
 [testenv]
-extras = dev
+skip_install = true
+
+passenv =
+    DISPLAY
+    XAUTHORITY
+    HOME
+    USERNAME
+    USER
+    XDG_*
+    CI
+    OS
+    PYTHONIOENCODING
+    PIP_DOWNLOAD_CACHE
+
+setenv =
+    PYTHONPATH = {toxinidir}
+
+allowlist_externals =
+    bash
+
+deps =
+    -e .[test,dev]
 
 commands =
-  {envpython} -m pytest {posargs:}
-  {envpython} -m pylint cpplint.py
-  {envpython} -m flake8 cpplint.py
+  python -m pytest {posargs:}
+  python -m pylint cpplint.py
+  python -m flake8 cpplint.py
+
+[testenv:build]
+skip_install = true
+
+passenv =
+    pythonLocation
+    CI
+    PYTHONIOENCODING
+    PIP_DOWNLOAD_CACHE
+
+deps =
+    pip>=21.1
+    build
+    twine
+
+commands =
+    python -m build .
+    twine check dist/*
+
+[testenv:check]
+skip_install = true
+allowlist_externals =
+    bash
+
+passenv =
+    CI
+    GITHUB*
+    PIP_DOWNLOAD_CACHE
+
+deps =
+    pip>=21.1
+
+changedir =
+    dist/
+
+commands =
+    python -m pip install cpplint  --force-reinstall --pre --prefer-binary -f ./
+
+[testenv:clean]
+skip_install = true
+allowlist_externals =
+    bash
+
+deps =
+    pip>=21.1
+
+commands =
+    bash -c 'rm -rf build/ dist/ __pycache__/ *.egg-info/'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3,py3{8,9,10,11,12,13}-{linux,macos,windows}
+envlist = pypy3,py3{9,10,11,12,13}-{linux,macos,windows}
 skip_missing_interpreters = true
 isolated_build = true
 skipsdist = true
@@ -16,8 +16,11 @@ python =
 PLATFORM =
     ubuntu-latest: linux
     ubuntu-22.04: linux
+    ubuntu-24.04-arm: linux
     macos-latest: macos
+    macos-15: macos
     windows-latest: windows
+    windows-2025: windows
 
 [testenv]
 skip_install = true
@@ -44,9 +47,9 @@ deps =
     -e .[test,dev]
 
 commands =
-  python -m pytest {posargs:}
-  python -m pylint cpplint.py
-  python -m flake8 cpplint.py
+    python -m pytest {posargs:}
+    python -m pylint cpplint.py
+    python -m flake8 cpplint.py
 
 [testenv:build]
 skip_install = true
@@ -83,7 +86,7 @@ changedir =
     dist/
 
 commands =
-    python -m pip install cpplint  --force-reinstall --pre --prefer-binary -f ./
+    python -m pip install cpplint  --force --pre --prefer-binary -f ./
 
 [testenv:clean]
 skip_install = true
@@ -94,4 +97,4 @@ deps =
     pip>=21.1
 
 commands =
-    bash -c 'rm -rf build/ dist/ __pycache__/ *.egg-info/'
+    bash -c 'rm -rf build/ dist/ __pycache__/ *.egg-info/ .coverage'


### PR DESCRIPTION
* update workflow action/python versions and packaging, remove errors from setup.py
* add workaround for py39 on macos installed with broken setuptools
* update python matrix and expand tox file with build/check/clean cmds

Sorry, I couldn't wait for open PRs to merge so I tested the 2 C-compat PRs (#306 and #308) and this cleanup PR in the relevant workflow and our project CI is Green again.  This PR also contains a GH release workflow to publish GH release from a tag push.  Thanks!