### PR TITLE
ci: Update Python and test more platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Python 3.9 is the last non-EOL version. Also adapt tox.ini
-        python-version: ['3.9', 'pypy3.11', '3.13']
+        python-version: ['3.9', 'pypy3.11', '3.12']
         # macOS in Intel, macOS on ARM, Ubuntu on x64, Ubuntu on ARM, Windows on X64
         os: [macos-13, macos-latest, ubuntu-latest, ubuntu-20.04-arm, windows-latest, windows-2025]
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         # Python 3.9 is the last non-EOL version. Also adapt tox.ini
         python-version: ['3.9', 'pypy3.11', '3.12']
         # macOS in Intel, macOS on ARM, Ubuntu on x64, Ubuntu on ARM, Windows on X64
-        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-20.04-arm, windows-latest, windows-2025]
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-2025]
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Python 3.8 is the last non-EOL version. Also adapt tox.ini
-        python-version: ['3.8', 'pypy3.10', '3.12']
-        os: [ubuntu-latest, windows-latest]
+        # Python 3.9 is the last non-EOL version. Also adapt tox.ini
+        python-version: ['3.9', 'pypy3.11', '3.13']
+        # macOS in Intel, macOS on ARM, Ubuntu on x64, Ubuntu on ARM, Windows on X64
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-20.04-arm, windows-latest, windows-2025]
       fail-fast: false
 
     steps:
@@ -27,13 +28,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
           cache: 'pip'
           cache-dependency-path: '**/test-requirements'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
+          python -m pip install --editable .[dev]
           python -m pip install 'tox-gh-actions<4.0.0'
       - name: Test with tox
         run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
-envlist = py38, py39, py3.10, py311, py312, pypy3
+envlist = py39, py3.10, py311, py312, py313, pypy3
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
-    pypy3.10: pypy3
+    3.13: py313
+    pypy3.11: pypy3
 
 [testenv]
 extras = dev
 
 commands =
   {envpython} -m pytest {posargs:}
-  {envpython} -m pylint cpplint.py
-  {envpython} -m flake8 cpplint.py
+  {envpython} -m pylint
+  {envpython} -m flake8 .

--- a/tox.ini
+++ b/tox.ini
@@ -16,5 +16,5 @@ extras = dev
 
 commands =
   {envpython} -m pytest {posargs:}
-  {envpython} -m pylint
+  {envpython} -m pylint .
   {envpython} -m flake8 .


### PR DESCRIPTION
* https://devguide.python.org/versions
* https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

---

Revert Python 3.13 upgrade because of
* #311