### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,7 +43,7 @@ A large long-overdue modernization of the codebase!
 * `build/class` and `build/namespaces` no longer check for whether a namespace or class has a closing brace from @geoffviola (https://github.com/cpplint/cpplint/pull/272). This should be done in a more efficient manner by a compiler or language server instead. As part of this, the `build/class` category was removed.
 * Fixed false positive when an if/else statement has braces everywhere but one of the closing braces before the final block is on a separate line by @aaronliu0130 (https://github.com/cpplint/cpplint/pull/265)
 * For header files, the check for a header guard's name will now be cached and only run once, as opposed to previously being run on every line. This results in a ~5.6% reduction in run time thanks to @matyalatte, who figured it out, and @aaronliu0130 for implementing it (https://github.com/cpplint/cpplint/pull/291)
-* Usages of the deprecated sre_compile were refectored by @jspricke (https://github.com/cpplint/cpplint/pull/214)
+* Usages of the deprecated sre_compile were refactored by @jspricke (https://github.com/cpplint/cpplint/pull/214)
 * Usages of deprecated unittest aliases were refactored by @tirkarthi (https://github.com/cpplint/cpplint/pull/182), @aaronliu0130 and @jayvdb
 * Typos in this changelog, comments and functions were fixed by @jayvdb (https://github.com/cpplint/cpplint/pull/245), @aaronliu0130 and @tkruse
 * %-strings were modernized into f-strings by @aaronliu0130

--- a/cpplint.py
+++ b/cpplint.py
@@ -5255,7 +5255,7 @@ def _GetTextInside(text, start_pattern):
   Given a string of lines and a regular expression string, retrieve all the text
   following the expression and between opening punctuation symbols like
   (, [, or {, and the matching close-punctuation symbol. This properly nested
-  occurrences of the punctuations, so for the text like
+  occurrences of the punctuation, so for the text like
     printf(a(), b(c()));
   a call to _GetTextInside(text, r'printf\(') will return 'a(), b(c())'.
   start_pattern must match string having an open punctuation symbol at the end.
@@ -5272,7 +5272,7 @@ def _GetTextInside(text, start_pattern):
   # TODO(unknown): Audit cpplint.py to see what places could be profitably
   # rewritten to use _GetTextInside (and use inferior regexp matching today).
 
-  # Give opening punctuations to get the matching close-punctuations.
+  # Give opening punctuation to get the matching close-punctuation.
   matching_punctuation = {'(': ')', '{': '}', '[': ']'}
   closing_punctuation = set(dict.values(matching_punctuation))
 
@@ -5286,22 +5286,22 @@ def _GetTextInside(text, start_pattern):
       'start_pattern must ends with an opening punctuation.')
   assert text[start_position - 1] in matching_punctuation, (
       'start_pattern must ends with an opening punctuation.')
-  # Stack of closing punctuations we expect to have in text after position.
+  # Stack of closing punctuation we expect to have in text after position.
   punctuation_stack = [matching_punctuation[text[start_position - 1]]]
   position = start_position
   while punctuation_stack and position < len(text):
     if text[position] == punctuation_stack[-1]:
       punctuation_stack.pop()
     elif text[position] in closing_punctuation:
-      # A closing punctuation without matching opening punctuations.
+      # A closing punctuation without matching opening punctuation.
       return None
     elif text[position] in matching_punctuation:
       punctuation_stack.append(matching_punctuation[text[position]])
     position += 1
   if punctuation_stack:
-    # Opening punctuations left without matching close-punctuations.
+    # Opening punctuation left without matching close-punctuation.
     return None
-  # punctuations match.
+  # punctuation match.
   return text[start_position:position - 1]
 
 

--- a/samples/boost-sample/include/boost/math/octonion.hpp
+++ b/samples/boost-sample/include/boost/math/octonion.hpp
@@ -925,7 +925,7 @@ namespace boost
     
 // There is quite a lot of repetition in the code below. This is intentional.
 // The last conditional block is the normal form, and the others merely
-// consist of workarounds for various compiler deficiencies. Hopefuly, when
+// consist of workarounds for various compiler deficiencies. Hopefully, when
 // more compilers are conformant and we can retire support for those that are
 // not, we will be able to remove the clutter. This is makes the situation
 // (painfully) explicit.
@@ -3970,7 +3970,7 @@ namespace boost
 #undef    BOOST_OCTONION_VALARRAY_LOADER
         
         
-        // Note:    This is the Cayley norm, not the Euclidian norm...
+        // Note:    This is the Cayley norm, not the Euclidean norm...
         
         template<typename T>
         inline T                                norm(octonion<T> const & o)

--- a/samples/chromium-sample/src/chrome_content_renderer_client.cc
+++ b/samples/chromium-sample/src/chrome_content_renderer_client.cc
@@ -1194,12 +1194,12 @@ WebPlugin* ChromeContentRendererClient::CreatePlugin(
 #endif  // BUILDFLAG(ENABLE_PLUGINS)
 
 // For NaCl content handling plugins, the NaCl manifest is stored in an
-// additonal 'nacl' param associated with the MIME type.
+// additional 'nacl' param associated with the MIME type.
 //  static
 GURL ChromeContentRendererClient::GetNaClContentHandlerURL(
     const std::string& actual_mime_type,
     const content::WebPluginInfo& plugin) {
-  // Look for the manifest URL among the MIME type's additonal parameters.
+  // Look for the manifest URL among the MIME type's additional parameters.
   for (const auto& mime_type : plugin.mime_types) {
     if (mime_type.mime_type == actual_mime_type) {
       for (const auto& p : mime_type.additional_params) {

--- a/samples/codelite-sample/src/pptable.cpp
+++ b/samples/codelite-sample/src/pptable.cpp
@@ -155,7 +155,7 @@ void PPToken::processArgs(const wxString &argsList)
 {
 	args = wxStringTokenize(argsList, wxT(","), wxTOKEN_STRTOK);
 
-	// replace all occurances of 'arg' with %1, %2 etc
+	// replace all occurrences of 'arg' with %1, %2 etc
 	for(size_t i=0; i<args.GetCount(); i++) {
 		wxString replaceWith = wxString::Format(wxT("%%%d"), (int)i);
 #if wxVERSION_NUMBER < 2900
@@ -511,7 +511,7 @@ wxString PPTable::Export()
 
 		} else {
 			// macros with replacement but they are not in a form of a function
-			// we take only macros that thier replacement is not a number
+			// we take only macros that their replacement is not a number
 			long v(-1);
 			if(!replacement.ToLong(&v) && !replacement.ToLong(&v, 8) && !replacement.ToLong(&v, 16) && replacement.find(wxT('"')) == wxString::npos && !replacement.StartsWith(wxT("0x"))) {
 				table << iter->second.fullname() << wxT("=") << replacement << wxT("\n");

--- a/samples/protobuf-sample/src/descriptor_unittest.cc
+++ b/samples/protobuf-sample/src/descriptor_unittest.cc
@@ -419,7 +419,7 @@ TEST_F(FileDescriptorTest, FindExtensionByNumber) {
 }
 
 TEST_F(FileDescriptorTest, BuildAgain) {
-  // Test that if te call BuildFile again on the same input we get the same
+  // Test that if the call BuildFile again on the same input we get the same
   // FileDescriptor back.
   FileDescriptorProto file;
   foo_file_->CopyTo(&file);
@@ -431,7 +431,7 @@ TEST_F(FileDescriptorTest, BuildAgain) {
 }
 
 TEST_F(FileDescriptorTest, BuildAgainWithSyntax) {
-  // Test that if te call BuildFile again on the same input we get the same
+  // Test that if the call BuildFile again on the same input we get the same
   // FileDescriptor back even if syntax param is specified.
   FileDescriptorProto proto_syntax2;
   proto_syntax2.set_name("foo_syntax2");
@@ -2251,7 +2251,7 @@ TEST_F(MiscTest, DefaultValues) {
   AddField(message_proto, "empty_string", 11, label, FD::TYPE_STRING)
     ->set_default_value("");
 
-  // Add a second set of fields with implicit defalut values.
+  // Add a second set of fields with implicit default values.
   AddField(message_proto, "implicit_int32" , 21, label, FD::TYPE_INT32 );
   AddField(message_proto, "implicit_int64" , 22, label, FD::TYPE_INT64 );
   AddField(message_proto, "implicit_uint32", 23, label, FD::TYPE_UINT32);
@@ -4647,7 +4647,7 @@ TEST_F(ValidationErrorTest, RepeatedMessageOption) {
 }
 
 TEST_F(ValidationErrorTest, ResolveUndefinedOption) {
-  // The following should produce an eror that baz.bar is resolved but not
+  // The following should produce an error that baz.bar is resolved but not
   // defined.
   // foo.proto:
   //   package baz

--- a/samples/v8-sample/src/interface-descriptors.h
+++ b/samples/v8-sample/src/interface-descriptors.h
@@ -180,7 +180,7 @@ class V8_EXPORT_PRIVATE CallInterfaceDescriptorData {
   RegList allocatable_registers_ = 0;
 
   // |registers_params_| defines registers that are used for parameter passing.
-  // |machine_types_| defines machine types for resulting values and incomping
+  // |machine_types_| defines machine types for resulting values and incoming
   // parameters.
   // Both arrays are allocated dynamically by the InterfaceDescriptor and
   // freed on destruction. This is because static arrays cause creation of
@@ -945,7 +945,7 @@ class BinaryOpDescriptor : public CallInterfaceDescriptor {
   DECLARE_DESCRIPTOR(BinaryOpDescriptor, CallInterfaceDescriptor)
 };
 
-// This desciptor is shared among String.p.charAt/charCodeAt/codePointAt
+// This descriptor is shared among String.p.charAt/charCodeAt/codePointAt
 // as they all have the same interface.
 class StringAtDescriptor final : public CallInterfaceDescriptor {
  public:


### PR DESCRIPTION
% `codespell --ignore-words-list=alse,ons --write-changes`
* https://pypi.org/project/codespell
