### PR TITLE
Prepare for release 2.0.1 and update changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,22 +2,23 @@
 Changelog
 *********
 
-2.0.1 (2025-01-??)
+2.0.1 (2025-03-08)
 ==================
 
 Yet another overdue... hotfix. Sorry this took so long.
 
-* The false positive for indented function parameters in namespaces was eradicated.
-* build/include-what-you-use now recognizes c-style headers, such as <stdio.h> for symbols from <cstdio>. (https://github.com/cpplint/cpplint/pull/306)
+* The false positive for indented function parameters in namespaces was eradicated. (https://github.com/cpplint/cpplint/pull/304)
+* build/include-what-you-use now recognizes c-style headers, such as <stdio.h> for symbols from <cstdio>. (https://github.com/cpplint/cpplint/pull/319)
 
 2.0 (2024-10-06)
 ================
 
 A large long-overdue modernization of the codebase!
 
-* Python 2 is no longer supported. Python 3.12 support was added along with fixed CI for 3.7 and 3.8, courtesy of @jayvdb
+* Python 2 and 3.7 are no longer supported. Python 3.12 support was added along with fixed CI for 3.7 and 3.8, courtesy of @jayvdb
    * As a result of all this, setup.py's lint subcommand was removed. Please run the commands directly instead.
 * You can now specify blocks of code that exclude linting with NOLINTBEGIN and NOLINTEND, courtesy of @n3world (https://github.com/cpplint/cpplint/pull/213)
+* The config filename can now be specified through `--config` thanks to @gedankenexperimenter (https://github.com/cpplint/cpplint/pull/198). Specifying a config file not under the current directory will be available in a future release.
 * The `--filter` option can now be only applied to a specific file or even a specific line through utilizing colons, e.g. `-filter=-whitespace:foo.h,+whitespace/braces:foo.h:418`. Courtesy of @PhilLab (https://github.com/cpplint/cpplint/pull/171)
 * NOLINT and NOLINTNEXTLINE comments now support a comma-separated list of categories, courtesy of @n3world (https://github.com/cpplint/cpplint/pull/220)
 * NOLINT and NOLINTNEXTLINE will now ignore categories known to be from clang-tidy thanks to @xatier (https://github.com/cpplint/cpplint/pull/231)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 *********
 
-2.0.1 (2025-03-08)
+2.0.1 (2025-03-09)
 ==================
 
 Yet another overdue... hotfix. Sorry this took so long.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Yet another overdue... hotfix. Sorry this took so long.
 
 A large long-overdue modernization of the codebase!
 
-* Python 2 and 3.7 are no longer supported. Python 3.12 support was added along with fixed CI for 3.7 and 3.8, courtesy of @jayvdb
+* Python versions less than 3.8 are no longer supported. Python 3.12 support was added along with fixed CI for 3.7 and 3.8, courtesy of @jayvdb
    * As a result of all this, setup.py's lint subcommand was removed. Please run the commands directly instead.
 * You can now specify blocks of code that exclude linting with NOLINTBEGIN and NOLINTEND, courtesy of @n3world (https://github.com/cpplint/cpplint/pull/213)
 * The config filename can now be specified through `--config` thanks to @gedankenexperimenter (https://github.com/cpplint/cpplint/pull/198). Specifying a config file not under the current directory will be available in a future release.

--- a/cpplint.py
+++ b/cpplint.py
@@ -59,7 +59,7 @@ import xml.etree.ElementTree
 # if empty, use defaults
 _valid_extensions = set([])
 
-__VERSION__ = '2.0.0'
+__VERSION__ = '2.0.1'
 
 _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]


### PR DESCRIPTION
The test failures in #318 gave me two thoughts:
1. why the heck did that error not appear when I merged your "type hints" suggestion
2. We now have all the more reason to bump Python to 3.9, and I really think we should get 2.0.1. out first with the pretty big bugfix before bumping. So let's release 2.0.1 and then continue development.

# What's included in this PR
* correct links for 2.0.1 changes
* it's not january anymore aaron...
* retroactively add some things that were included in 2.0 but not in its changgelog
* bump version