### PR TITLE
Ruff rules for comprehensions and performance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Yet another overdue... hotfix. Sorry this took so long.
 
 * The false positive for indented function parameters in namespaces was eradicated. (https://github.com/cpplint/cpplint/pull/304)
 * build/include-what-you-use now recognizes c-style headers, such as <stdio.h> for symbols from <cstdio>. (https://github.com/cpplint/cpplint/pull/319)
+* Ruff was ran on the project to improve performance and reader comprehension thanks to @cclauss.
 
 2.0 (2024-10-06)
 ================

--- a/cpplint.py
+++ b/cpplint.py
@@ -57,7 +57,7 @@ import unicodedata
 import xml.etree.ElementTree
 
 # if empty, use defaults
-_valid_extensions = set([])
+_valid_extensions = set()
 
 __VERSION__ = '2.0.1'
 
@@ -826,7 +826,7 @@ _CHECK_MACROS = [
     ]
 
 # Replacement macros for CHECK/DCHECK/EXPECT_TRUE/EXPECT_FALSE
-_CHECK_REPLACEMENT = dict([(macro_var, {}) for macro_var in _CHECK_MACROS])
+_CHECK_REPLACEMENT = {macro_var: {} for macro_var in _CHECK_MACROS}
 
 for op, replacement in [('==', 'EQ'), ('!=', 'NE'),
                         ('>=', 'GE'), ('>', 'GT'),
@@ -945,7 +945,7 @@ _config_filename = "CPPLINT.cfg"
 
 # Treat all headers starting with 'h' equally: .h, .hpp, .hxx etc.
 # This is set by --headers flag.
-_hpp_headers = set([])
+_hpp_headers = set()
 
 class ErrorSuppressions:
   """Class to track all error suppressions for cpplint"""
@@ -1038,13 +1038,12 @@ def GetHeaderExtensions():
     return _hpp_headers
   if _valid_extensions:
     return {h for h in _valid_extensions if 'h' in h}
-  return set(['h', 'hh', 'hpp', 'hxx', 'h++', 'cuh'])
+  return {'h', 'hh', 'hpp', 'hxx', 'h++', 'cuh'}
 
 # The allowed extensions for file names
 # This is set by --extensions flag
 def GetAllExtensions():
-  return GetHeaderExtensions().union(_valid_extensions or set(
-    ['c', 'cc', 'cpp', 'cxx', 'c++', 'cu']))
+  return GetHeaderExtensions().union(_valid_extensions or {'c', 'cc', 'cpp', 'cxx', 'c++', 'cu'})
 
 def ProcessExtensionsOption(val):
   global _valid_extensions
@@ -1101,7 +1100,7 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
     if categories in (None, '(*)'):  # => "suppress all"
       ProcessCategory(None)
     elif categories.startswith('(') and categories.endswith(')'):
-      for category in set(map(lambda c: c.strip(), categories[1:-1].split(','))):
+      for category in {c.strip() for c in categories[1:-1].split(',')}:
         if category in _ERROR_CATEGORIES:
           ProcessCategory(category)
         elif any(c for c in _OTHER_NOLINT_CATEGORY_PREFIXES if category.startswith(c)):
@@ -6073,13 +6072,12 @@ _HEADERS_FUNCTIONS = (
 
 _re_pattern_headers_maybe_templates = []
 for _header, _templates in _HEADERS_MAYBE_TEMPLATES:
-  for _template in _templates:
-    # Match max<type>(..., ...), max(..., ...), but not foo->max, foo.max or
-    # 'type::max()'.
-    _re_pattern_headers_maybe_templates.append(
-        (re.compile(r'((\bstd::)|[^>.:])\b' + _template + r'(<.*?>)?\([^\)]'),
-            _template,
-            _header))
+  # Match max<type>(..., ...), max(..., ...), but not foo->max, foo.max or
+  # 'type::max()'.
+  _re_pattern_headers_maybe_templates.extend(
+      (re.compile(r'((\bstd::)|[^>.:])\b' + _template + r'(<.*?>)?\([^\)]'),
+          _template,
+          _header) for _template in _templates)
 
 # Map is often overloaded. Only check, if it is fully qualified.
 # Match 'std::map<type>(...)', but not 'map<type>(...)''
@@ -6091,29 +6089,26 @@ _re_pattern_headers_maybe_templates.append(
 # Other scripts may reach in and modify this pattern.
 _re_pattern_templates = []
 for _header, _templates in _HEADERS_CONTAINING_TEMPLATES:
-  for _template in _templates:
-    _re_pattern_templates.append(
-        (re.compile(r'((^|(^|\s|((^|\W)::))std::)|[^>.:]\b)' + _template + r'\s*\<'),
-         _template + '<>',
-         _header))
+  _re_pattern_templates.extend(
+      (re.compile(r'((^|(^|\s|((^|\W)::))std::)|[^>.:]\b)' + _template + r'\s*\<'),
+       _template + '<>',
+       _header) for _template in _templates)
 
 _re_pattern_types_or_objs = []
 for _header, _types_or_objs in _HEADERS_TYPES_OR_OBJS:
-  for _type_or_obj in _types_or_objs:
-    _re_pattern_types_or_objs.append(
-        (re.compile(r'\b' + _type_or_obj + r'\b'),
-            _type_or_obj,
-            _header))
+  _re_pattern_types_or_objs.extend(
+      (re.compile(r'\b' + _type_or_obj + r'\b'),
+          _type_or_obj,
+          _header) for _type_or_obj in _types_or_objs)
 
 _re_pattern_functions = []
 for _header, _functions in _HEADERS_FUNCTIONS:
-  for _function in _functions:
-    # Match printf(..., ...), but not foo->printf, foo.printf or
-    # 'type::printf()'.
-    _re_pattern_functions.append(
-        (re.compile(r'([^>.]|^)\b' + _function + r'\([^\)]'),
-            _function,
-            _header))
+  # Match printf(..., ...), but not foo->printf, foo.printf or
+  # 'type::printf()'.
+  _re_pattern_functions.extend(
+      (re.compile(r'([^>.]|^)\b' + _function + r'\([^\)]'),
+          _function,
+          _header) for _function in _functions)
 
 def FilesBelongToSameModule(filename_cc, filename_h):
   """Check if these two filenames belong to the same module.
@@ -6750,8 +6745,8 @@ def PrintUsage(message):
   Args:
     message: The optional error message.
   """
-  sys.stderr.write(_USAGE  % (sorted(list(GetAllExtensions())),
-       ','.join(sorted(list(GetAllExtensions()))),
+  sys.stderr.write(_USAGE  % (sorted(GetAllExtensions()),
+       ','.join(sorted(GetAllExtensions())),
        sorted(GetHeaderExtensions()),
        ','.join(sorted(GetHeaderExtensions()))))
 
@@ -6933,11 +6928,8 @@ def _ExpandDirectories(filenames):
           fullname = fullname[len('.' + os.path.sep):]
         expanded.add(fullname)
 
-  filtered = []
-  for filename in expanded:
-    if os.path.splitext(filename)[1][1:] in GetAllExtensions():
-      filtered.append(filename)
-  return filtered
+  return [filename for filename in expanded
+          if os.path.splitext(filename)[1][1:] in GetAllExtensions()]
 
 def _FilterExcludedFiles(fnames):
   """Filters out files listed in the --exclude command line switch. File paths

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4260,27 +4260,27 @@ class CpplintTest(CpplintTestBase):
       self.assertEqual(['foo.h'],
                        cpplint.ParseArguments(['--linelength=120', 'foo.h']))
       self.assertEqual(120, cpplint._line_length)
-      self.assertEqual(set(['h', 'hh', 'hpp', 'hxx', 'h++', 'cuh']), cpplint.GetHeaderExtensions())  # Default value
+      self.assertEqual({'h', 'hh', 'hpp', 'hxx', 'h++', 'cuh'}, cpplint.GetHeaderExtensions())  # Default value
 
       cpplint._hpp_headers = old_headers
       cpplint._valid_extensions = old_valid_extensions
       self.assertEqual(['foo.h'],
                        cpplint.ParseArguments(['--headers=h', 'foo.h']))
-      self.assertEqual(set(['h', 'c', 'cc', 'cpp', 'cxx', 'c++', 'cu']), cpplint.GetAllExtensions())
+      self.assertEqual({'h', 'c', 'cc', 'cpp', 'cxx', 'c++', 'cu'}, cpplint.GetAllExtensions())
 
       cpplint._hpp_headers = old_headers
       cpplint._valid_extensions = old_valid_extensions
       self.assertEqual(['foo.h'],
                        cpplint.ParseArguments(['--extensions=hpp,cpp,cpp', 'foo.h']))
-      self.assertEqual(set(['hpp', 'cpp']), cpplint.GetAllExtensions())
-      self.assertEqual(set(['hpp']), cpplint.GetHeaderExtensions())
+      self.assertEqual({'hpp', 'cpp'}, cpplint.GetAllExtensions())
+      self.assertEqual({'hpp'}, cpplint.GetHeaderExtensions())
 
       cpplint._hpp_headers = old_headers
       cpplint._valid_extensions = old_valid_extensions
       self.assertEqual(['foo.h'],
                        cpplint.ParseArguments(['--extensions=cpp,cpp', '--headers=hpp,h', 'foo.h']))
-      self.assertEqual(set(['hpp', 'h']), cpplint.GetHeaderExtensions())
-      self.assertEqual(set(['hpp', 'h', 'cpp']), cpplint.GetAllExtensions())
+      self.assertEqual({'hpp', 'h'}, cpplint.GetHeaderExtensions())
+      self.assertEqual({'hpp', 'h', 'cpp'}, cpplint.GetAllExtensions())
 
     finally:
       sys.stdout = sys.__stdout__
@@ -4330,8 +4330,8 @@ class CpplintTest(CpplintTestBase):
     finally:
         os.chdir(working_dir)
         shutil.rmtree(temp_dir)
-        cpplint._hpp_headers = set([])
-        cpplint._valid_extensions = set([])
+        cpplint._hpp_headers = set()
+        cpplint._valid_extensions = set()
 
   def testRecursiveExclude(self):
     working_dir = os.getcwd()
@@ -4356,7 +4356,7 @@ class CpplintTest(CpplintTestBase):
       ]
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['src'])
-      self.assertEqual(set(['src']), set(actual))
+      self.assertEqual({'src'}, set(actual))
 
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['--recursive', 'src'])
@@ -4374,11 +4374,11 @@ class CpplintTest(CpplintTestBase):
           '--exclude=src/two.cc', '--exclude=src/three.cc', 'src'])
       self.assertEqual(set(expected), set(actual))
 
-      expected = set([
+      expected = {
         os.path.join('src2', 'one.cc'),
         os.path.join('src2', 'two.cc'),
         os.path.join('src2', 'three.cc')
-      ])
+      }
       cpplint._excludes = None
       actual = cpplint.ParseArguments(['--recursive',
           '--exclude=src', '.'])
@@ -5629,8 +5629,8 @@ class OrderOfIncludesTest(CpplintTestBase):
                                       False))
 
   def testTryDropCommonSuffixes(self):
-    cpplint._hpp_headers = set([])
-    cpplint._valid_extensions = set([])
+    cpplint._hpp_headers = set()
+    cpplint._valid_extensions = set()
     self.assertEqual('foo/foo', cpplint._DropCommonSuffixes('foo/foo-inl.h'))
     self.assertEqual('foo/foo', cpplint._DropCommonSuffixes('foo/foo-inl.hxx'))
     self.assertEqual('foo/foo', cpplint._DropCommonSuffixes('foo/foo-inl.h++'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ lint.select = [
   "ASYNC", # flake8-async
   "B",     # flake8-bugbear
   "BLE",   # flake8-blind-except
+  "C4",    # flake8-comprehensions
   "C90",   # McCabe cyclomatic complexity
   "DJ",    # flake8-django
   "DTZ",   # flake8-datetimez
@@ -113,7 +114,6 @@ lint.select = [
   "YTT",   # flake8-2020
   # "ANN", # flake8-annotations
   # "ARG", # flake8-unused-arguments
-  # "C4",  # flake8-comprehensions
   # "COM", # flake8-commas
   # "CPY", # flake8-copyright
   # "D",   # pydocstyle


### PR DESCRIPTION
% `ruff check --select=C4,PERF --output-format=concise`
```
cpplint.py:60:21: C405 Unnecessary list literal (rewrite as a set literal)
cpplint.py:829:22: C404 Unnecessary list comprehension (rewrite as a dict comprehension)
cpplint.py:948:16: C405 Unnecessary list literal (rewrite as a set literal)
cpplint.py:1041:10: C405 Unnecessary list literal (rewrite as a set literal)
cpplint.py:1046:59: C405 Unnecessary list literal (rewrite as a set literal)
cpplint.py:1104:23: C417 Unnecessary `map()` usage (rewrite using a set comprehension)
cpplint.py:6072:5: PERF401 Use `list.extend` to create a transformed list
cpplint.py:6088:5: PERF401 Use `list.extend` to create a transformed list
cpplint.py:6096:5: PERF401 Use `list.extend` to create a transformed list
cpplint.py:6106:5: PERF401 Use `list.extend` to create a transformed list
cpplint.py:6743:31: C414 Unnecessary `list()` call within `sorted()`
cpplint.py:6744:17: C414 Unnecessary `list()` call within `sorted()`
cpplint.py:6930:7: PERF401 Use a list comprehension to create a transformed list
cpplint_unittest.py:4262:24: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4268:24: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4274:24: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4275:24: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4281:24: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4282:24: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4332:32: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4333:37: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4358:24: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:4376:18: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:5630:28: C405 Unnecessary list literal (rewrite as a set literal)
cpplint_unittest.py:5631:33: C405 Unnecessary list literal (rewrite as a set literal)
Found 25 errors.
No fixes available (20 hidden fixes can be enabled with the `--unsafe-fixes` option).
```