### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --editable .[dev]
+          pip install --editable ".[dev]"
       - name: Test with tox
         run: tox -e py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Python 3.8 is EOL. Also adapt tox.ini
-        python-version: ['3.8', 'pypy3.11', '3.x']
+        # Also adapt tox.ini on change
+        python-version: ['3.9', 'pypy3.11', '3.x']
         # macOS on ARM, Ubuntu on x86, Windows on X86
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 2.1.0 (TBA)
 ===========
 
-* Python versions less than 3.8 are no longer supported.
+* Python versions less than 3.9 are no longer supported.
 
 2.0.1 (2025-03-09)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,12 @@
 Changelog
 *********
 
-2.0.1 (2025-04-02)
+2.1.0 (TBA)
+===========
+
+* Python versions less than 3.8 are no longer supported.
+
+2.0.1 (2025-03-09)
 ==================
 
 Yet another overdue... hotfix. Sorry this took so long.

--- a/cpplint.py
+++ b/cpplint.py
@@ -41,7 +41,7 @@ We do a small hack, which is to ignore //'s with "'s after them on the
 same line, but it is far from perfect (in either direction).
 """
 
-from __future__ import annotations
+from __future__ import annotations  # PEP 604 not in 3.9
 
 import codecs
 import collections
@@ -6858,8 +6858,7 @@ def FilesBelongToSameModule(filename_cc, filename_h):
     filename_cc = filename_cc.replace("/internal/", "/")
 
     filename_h = filename_h[: -(len(fileinfo_h.Extension()))]
-    if filename_h.endswith("-inl"):
-        filename_h = filename_h[: -len("-inl")]
+    filename_h = filename_h.removesuffix("-inl")
     filename_h = filename_h.replace("/public/", "/")
     filename_h = filename_h.replace("/internal/", "/")
 
@@ -7701,8 +7700,7 @@ def _ExpandDirectories(filenames):
         for root, _, files in os.walk(filename):
             for loopfile in files:
                 fullname = os.path.join(root, loopfile)
-                if fullname.startswith("." + os.path.sep):
-                    fullname = fullname[len("." + os.path.sep) :]
+                fullname = fullname.removeprefix("." + os.path.sep)
                 expanded.add(fullname)
 
     return [

--- a/cpplint.py
+++ b/cpplint.py
@@ -61,7 +61,7 @@ import xml.etree.ElementTree
 # if empty, use defaults
 _valid_extensions: set[str] = set()
 
-__VERSION__ = "2.1.0"
+__VERSION__ = "2.0.1"
 
 _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]

--- a/cpplint.py
+++ b/cpplint.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 import codecs
 import collections
 import copy
-import getopt  # pylint: disable=deprecated-module
+import getopt
 import glob
 import itertools
 import math  # for log

--- a/cpplint.py
+++ b/cpplint.py
@@ -61,7 +61,7 @@ import xml.etree.ElementTree
 # if empty, use defaults
 _valid_extensions: set[str] = set()
 
-__VERSION__ = "2.0.1"
+__VERSION__ = "2.1.0"
 
 _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]

--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -30,8 +30,6 @@
 
 """Command Line interface integration test for cpplint.py."""
 
-from __future__ import annotations
-
 import contextlib
 import glob
 import os

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -32,8 +32,6 @@
 
 # TODO(unknown): Add a good test that tests UpdateIncludeState.
 
-from __future__ import annotations
-
 import codecs
 import os
 import platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [  ]
 optional-dependencies.dev = [
   "mypy",
   "parameterized",
-  "pylint==3.3.5",
+  "pylint>=3.3.4",
   "pytest",
   "pytest-cov",
   "pytest-timeout",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [  ]
 optional-dependencies.dev = [
   "mypy",
   "parameterized",
-  "pylint>=3.3.5",
+  "pylint==3.3.5",
   "pytest",
   "pytest-cov",
   "pytest-timeout",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,6 @@ include-package-data = false
 dynamic.version = { attr = "cpplint.__VERSION__" }
 
 [tool.ruff]
-target-version = "py38"
-
 line-length = 100
 lint.select = [
   "A",     # flake8-builtins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
   { name = "Andrew Davis", email = "theandrewdavis@gmail.com" },
   { name = "cpplint developers" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -29,7 +29,6 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: C++",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -43,7 +42,7 @@ dependencies = [  ]
 optional-dependencies.dev = [
   "mypy",
   "parameterized",
-  "pylint>=2.11",
+  "pylint>=3.3.5",
   "pytest",
   "pytest-cov",
   "pytest-timeout",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py3.10, py311, py312, py313, pypy3
+envlist = py39, py310, py311, py312, py313, pypy3
 skip_missing_interpreters = true
 
 


### PR DESCRIPTION
Pylint released their update on dedeprecating the getopt and optparse modules.Should merge this after we release 2.0.1.