### PR TITLE
pre-commit autoupdate 2025-03-14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.10.0
     hooks:
       - id: ruff
       - id: ruff-format
@@ -31,6 +31,6 @@ repos:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.23
+    rev: v0.24
     hooks:
       - id: validate-pyproject


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/codespell-project/codespell] already up to date!
[https://github.com/astral-sh/ruff-pre-commit] updating v0.9.10 -> v0.10.0
[https://github.com/pycqa/flake8] already up to date!
[https://github.com/tox-dev/pyproject-fmt] already up to date!
[https://github.com/abravalheri/validate-pyproject] updating v0.23 -> v0.24
```
% `pre-commit run --all-files`

https://astral.sh/blog/ruff-v0.10.0