### PR TITLE
ruff rule N805: First argument of a method should be named `self`

### DIFF
--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -176,8 +176,8 @@ class TestNoRepoSignature(TemporaryFolderClassSetup):
     def get_extra_command_args(self, cwd):
         return f" --repository {self._root} "
 
-    def _test_name_func(fun, _, x):
-        del fun
+    def _test_name_func(self, _, x):
+        del self
         return f"test{x.args[0].capitalize()}Sample-{x.args[1]}"
 
     @parameterized.expand(

--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -176,10 +176,6 @@ class TestNoRepoSignature(TemporaryFolderClassSetup):
     def get_extra_command_args(self, cwd):
         return f" --repository {self._root} "
 
-    def _test_name_func(self, _, x):
-        del self
-        return f"test{x.args[0].capitalize()}Sample-{x.args[1]}"
-
     @parameterized.expand(
         [
             (folder, case[:-4])
@@ -187,7 +183,7 @@ class TestNoRepoSignature(TemporaryFolderClassSetup):
             for case in os.listdir(f"./samples/{folder}-sample")
             if case.endswith(".def")
         ],
-        name_func=_test_name_func,
+        name_func=lambda fun, _, x: f"test{x.args[0].capitalize()}Sample-{x.args[1]}",
     )
     @pytest.mark.timeout(180)
     def testSamples(self, folder, case):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ lint.select = [
   "INT",   # flake8-gettext
   "ISC",   # flake8-implicit-str-concat
   "LOG",   # flake8-logging
+  "N",     # pep8-naming
   "NPY",   # NumPy-specific rules
   "PD",    # pandas-vet
   "PERF",  # Perflint
@@ -115,7 +116,6 @@ lint.select = [
   # "D",   # pydocstyle
   # "DOC", # pydoclint
   # "ERA", # eradicate
-  # "N",   # pep8-naming
   # "PTH", # flake8-use-pathlib
   # "RUF", # Ruff-specific rules
   # "S",   # flake8-bandit
@@ -127,6 +127,7 @@ lint.ignore = [
   "FBT003", # flake8-boolean-trap
   "FIX002", # flake8-fixme
   "ISC003", # flake8-implicit-str-concat
+  "N802",   # invalid-function-name
   "PIE790", # Unnecessary `pass` statement
 ]
 lint.per-file-ignores."cpplint.py" = [ "ICN001", "PERF401", "PLR5501", "PLW0603", "PLW2901", "SIM102", "SIM108" ]


### PR DESCRIPTION
This code is not deleting the function (method) but is instead deleting the class!

https://docs.astral.sh/ruff/rules/invalid-first-argument-name-for-method