### PR TITLE
cpplint_clitest.py: Function names should be lowercase

### DIFF
--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -76,7 +76,7 @@ def run_shell_command(cmd: str, args: str, cwd="."):
 
 
 class TestUsage:
-    def testHelp(self):
+    def test_help(self):
         (status, out, err) = run_shell_command(BASE_CMD, "--help")
         assert status == 0
         assert out == b""
@@ -186,7 +186,7 @@ class TestNoRepoSignature(TemporaryFolderClassSetup):
         name_func=lambda fun, _, x: f"test{x.args[0].capitalize()}Sample-{x.args[1]}",
     )
     @pytest.mark.timeout(180)
-    def testSamples(self, folder, case):
+    def test_samples(self, folder, case):
         self.check_def(os.path.join(f"./samples/{folder}-sample", case + ".def"))
 
 
@@ -198,7 +198,7 @@ class TestGitRepoSignature(TemporaryFolderClassSetup):
         with open(os.path.join(root, ".git"), "a"):
             pass
 
-    def testCodeliteSample(self):
+    def test_codelite_sample(self):
         self.check_all_in_folder("./samples/codelite-sample", 1)
 
 
@@ -210,7 +210,7 @@ class TestMercurialRepoSignature(TemporaryFolderClassSetup):
         with open(os.path.join(root, ".hg"), "a"):
             pass
 
-    def testCodeliteSample(self):
+    def test_codelite_sample(self):
         self.check_all_in_folder("./samples/codelite-sample", 1)
 
 
@@ -222,7 +222,7 @@ class TestSvnRepoSignature(TemporaryFolderClassSetup):
         with open(os.path.join(root, ".svn"), "a"):
             pass
 
-    def testCodeliteSample(self):
+    def test_codelite_sample(self):
         self.check_all_in_folder("./samples/codelite-sample", 1)
 
 

--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -183,7 +183,7 @@ class TestNoRepoSignature(TemporaryFolderClassSetup):
             for case in os.listdir(f"./samples/{folder}-sample")
             if case.endswith(".def")
         ],
-        name_func=lambda fun, _, x: f"test{x.args[0].capitalize()}Sample-{x.args[1]}",
+        name_func=lambda fun, _, x: f"test_{x.args[0]}_sample-{x.args[1]}",
     )
     @pytest.mark.timeout(180)
     def test_samples(self, folder, case):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,11 +127,19 @@ lint.ignore = [
   "FBT003", # flake8-boolean-trap
   "FIX002", # flake8-fixme
   "ISC003", # flake8-implicit-str-concat
-  "N802",   # invalid-function-name
   "PIE790", # Unnecessary `pass` statement
 ]
-lint.per-file-ignores."cpplint.py" = [ "ICN001", "PERF401", "PLR5501", "PLW0603", "PLW2901", "SIM102", "SIM108" ]
-lint.per-file-ignores."cpplint_unittest.py" = [ "FLY002", "PLW0604", "SIM115", "UP031" ]
+lint.per-file-ignores."cpplint.py" = [
+  "ICN001",
+  "N802",
+  "PERF401",
+  "PLR5501",
+  "PLW0603",
+  "PLW2901",
+  "SIM102",
+  "SIM108",
+]
+lint.per-file-ignores."cpplint_unittest.py" = [ "FLY002", "N802", "PLW0604", "SIM115", "UP031" ]
 lint.mccabe.max-complexity = 29
 lint.pylint.allow-magic-value-types = [ "bytes", "int", "str" ]
 lint.pylint.max-args = 10 # Default is 5


### PR DESCRIPTION
% `ruff rule N802 ` # https://docs.astral.sh/ruff/rules/invalid-function-name