### PR TITLE
`run_shell_command()` with `check=True` to avoid silent failures

### DIFF
--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -56,7 +56,7 @@ def run_shell_command(cmd: str, args: str, cwd="."):
         cwd: from which folder to run.
     """
     cmd, args = cmd.split(), args.split()
-    proc = subprocess.run(cmd + args, cwd=cwd, capture_output=True, check=False)
+    proc = subprocess.run(cmd + args, cwd=cwd, capture_output=True, check=True)
     out, err = proc.stdout, proc.stderr
 
     # Make output system-agnostic, aka support Windows


### PR DESCRIPTION
% `ruff rule PLW1510 ` # https://docs.astral.sh/ruff/rules/subprocess-run-without-check
> By default, `subprocess.run()` does not check the return code of the process it runs. This can lead to silent failures.

We have 17 silent failures in our tests.
```diff
def run_shell_command(cmd: str, args: str, cwd="."):
-   proc = subprocess.run(cmd + args, cwd=cwd, capture_output=True, check=False)
+   proc = subprocess.run(cmd + args, cwd=cwd, capture_output=True, check=True)
```