### PR TITLE
pylint-v3.3.5: getopt module is not deprecated

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -44,7 +44,7 @@ same line, but it is far from perfect (in either direction).
 import codecs
 import collections
 import copy
-import getopt  # pylint: disable=deprecated-module
+import getopt
 import glob
 import itertools
 import math  # for log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [  ]
 
 optional-dependencies.dev = [
   "parameterized",
-  "pylint>=2.11",
+  "pylint>=3.3.5",
   "pytest",
   "pytest-cov",
   "pytest-timeout",


### PR DESCRIPTION
* pylint-dev/pylint#10211 is now fixed on [`pylint` v3.3.5](https://github.com/pylint-dev/pylint/releases/tag/v3.3.5).

Blocked by:
* #334