### PR TITLE
Fix test refactoring

### DIFF
--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -95,8 +95,8 @@ class TemporaryFolderClassSetup:
     systemerr output (two blank lines at end).
     """
 
-    @classmethod
     @pytest.fixture(autouse=True, name="set_up()", scope="class")
+    @classmethod
     def set_up(cls):
         """setup tmp folder for testing with samples and custom additions by subclasses"""
         try:

--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -95,9 +95,9 @@ class TemporaryFolderClassSetup:
     systemerr output (two blank lines at end).
     """
 
-    @pytest.fixture(autouse=True, name="setUpClass()", scope="class")
     @classmethod
-    def setUpClass(cls):
+    @pytest.fixture(autouse=True, name="set_up()", scope="class")
+    def set_up(cls):
         """setup tmp folder for testing with samples and custom additions by subclasses"""
         try:
             cls._root = os.path.realpath(tempfile.mkdtemp())
@@ -105,13 +105,13 @@ class TemporaryFolderClassSetup:
             cls.prepare_directory(cls._root)
         except Exception:
             with contextlib.suppress(Exception):
-                cls.tearDownClass()
+                cls.tear_down()
             raise
         # yield
-        # cls.tearDownClass()
+        # cls.tear_down()
 
     @classmethod
-    def tearDownClass(cls):
+    def tear_down(cls):
         if cls._root:
             # pass
             shutil.rmtree(cls._root)

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -5257,7 +5257,8 @@ class TestCpplint(CpplintTestBase):
             ],
             error_collector,
         )
-        assert not any("build/header_guard" in line for line in error_collector.ResultList())
+        for line in error_collector.ResultList():
+            assert "build/header_guard" not in line
 
         # No header guard errors for old-style guard
         error_collector = ErrorCollector(self.assertTrue)
@@ -5271,7 +5272,8 @@ class TestCpplint(CpplintTestBase):
             ],
             error_collector,
         )
-        assert not any("build/header_guard" in line for line in error_collector.ResultList())
+        for line in error_collector.ResultList():
+            assert "build/header_guard" not in line
 
         old_verbose_level = cpplint._cpplint_state.verbose_level
         try:
@@ -5815,13 +5817,15 @@ class TestCpplint(CpplintTestBase):
         # Test that warning isn't issued if Copyright line appears early enough.
         error_collector = ErrorCollector(self.assertTrue)
         cpplint.ProcessFileData(file_path, "cc", [copyright_line], error_collector)
-        assert not any("legal/copyright" in line for line in error_collector.ResultList())
+        for line in error_collector.ResultList():
+            assert "legal/copyright" not in line
 
         error_collector = ErrorCollector(self.assertTrue)
         cpplint.ProcessFileData(
             file_path, "cc", ["" for unused_i in range(9)] + [copyright_line], error_collector
         )
-        assert not any("legal/copyright" in line for line in error_collector.ResultList())
+        for line in error_collector.ResultList():
+            assert "legal/copyright" not in line
 
     def testInvalidIncrement(self):
         self.TestLint(

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -60,7 +60,7 @@ def codecs_latin_encode(x):
 class ErrorCollector:
     # These are a global list, covering all categories seen ever.
     _ERROR_CATEGORIES = cpplint._ERROR_CATEGORIES
-    _SEEN_ERROR_CATEGORIES: dict[str, str] = {}
+    _SEEN_ERROR_CATEGORIES: set[str] = set()
 
     def __init__(self, assert_fn):
         """assert_fn: a function to call when we notice a problem."""
@@ -74,7 +74,7 @@ class ErrorCollector:
             'Message "%s" has category "%s",'
             " which is not in _ERROR_CATEGORIES" % (message, category),
         )
-        self._SEEN_ERROR_CATEGORIES[category] = 1
+        self._SEEN_ERROR_CATEGORIES.add(category)
         if cpplint._ShouldPrintError(category, confidence, filename, linenum):
             self._errors.append("%s  [%s] [%d]" % (message, category, confidence))
 
@@ -257,10 +257,7 @@ class CpplintTestBase:
 
     def TestMultiLineLintRE(self, code, expected_message_re):
         message = self.PerformMultiLineLint(code)
-        if not re.search(expected_message_re, message):
-            self.fail(
-                "Message was:\n" + message + 'Expected match to "' + expected_message_re + '"'
-            )
+        assert re.search(expected_message_re, message)
 
     def TestLanguageRulesCheck(self, file_name, code, expected_message):
         assert expected_message == self.PerformLanguageRulesCheck(file_name, code)
@@ -321,7 +318,8 @@ class TestCpplint(CpplintTestBase):
     def testNamespaceIndentationIndentedParameter(self):
         lines = [
             "namespace Test {",
-            "void foo(    SuperLongTypeName d = 418) { }",
+            "void foo(SuperLongTypeName d = 418,",
+            "   SuperLongTypeName e = 2.71) { }",
             "}  // namespace Test",
         ]
 
@@ -5259,9 +5257,7 @@ class TestCpplint(CpplintTestBase):
             ],
             error_collector,
         )
-        for line in error_collector.ResultList():
-            if line.find("build/header_guard") != -1:
-                self.fail("Unexpected error: %s" % line)
+        assert not any("build/header_guard" in line for line in error_collector.ResultList())
 
         # No header guard errors for old-style guard
         error_collector = ErrorCollector(self.assertTrue)
@@ -5275,9 +5271,7 @@ class TestCpplint(CpplintTestBase):
             ],
             error_collector,
         )
-        for line in error_collector.ResultList():
-            if line.find("build/header_guard") != -1:
-                self.fail("Unexpected error: %s" % line)
+        assert not any("build/header_guard" in line for line in error_collector.ResultList())
 
         old_verbose_level = cpplint._cpplint_state.verbose_level
         try:
@@ -5721,10 +5715,9 @@ class TestCpplint(CpplintTestBase):
     def TestLintLogCodeOnError(self, code, expected_message):
         # Special TestLint which logs the input code on error.
         result = self.PerformSingleLineLint(code)
-        if result != expected_message:
-            self.fail(
-                'For code: "%s"\nGot: "%s"\nExpected: "%s"' % (code, result, expected_message)
-            )
+        assert result == expected_message, (
+            f'For code: "{code}"\nGot: "{result}"\nExpected: "{expected_message}"'
+        )
 
     def testBuildStorageClass(self):
         qualifiers = [None, "const", "volatile"]
@@ -5822,17 +5815,13 @@ class TestCpplint(CpplintTestBase):
         # Test that warning isn't issued if Copyright line appears early enough.
         error_collector = ErrorCollector(self.assertTrue)
         cpplint.ProcessFileData(file_path, "cc", [copyright_line], error_collector)
-        for message in error_collector.ResultList():
-            if message.find("legal/copyright") != -1:
-                self.fail("Unexpected error: %s" % message)
+        assert not any("legal/copyright" in line for line in error_collector.ResultList())
 
         error_collector = ErrorCollector(self.assertTrue)
         cpplint.ProcessFileData(
             file_path, "cc", ["" for unused_i in range(9)] + [copyright_line], error_collector
         )
-        for message in error_collector.ResultList():
-            if message.find("legal/copyright") != -1:
-                self.fail("Unexpected error: %s" % message)
+        assert not any("legal/copyright" in line for line in error_collector.ResultList())
 
     def testInvalidIncrement(self):
         self.TestLint(
@@ -7183,7 +7172,9 @@ def run_around_tests(pytestconfig: pytest.Config):
     # obviously we're not going to see all the error categories.  So we
     # only run VerifyAllCategoriesAreSeen() when we don't filter for
     # specific tests.
-    if pytestconfig.getoption("-k", default=None) in {None, ""}:
+    if pytestconfig.getoption("-k", default=None) in {None, ""} and not any(
+        "::" in arg for arg in pytestconfig.args
+    ):
         ErrorCollector(None).VerifyAllCategoriesAreSeen()
 
 


### PR DESCRIPTION
Replace self.fail()s
Fix edge case of verifying categories when running pytest on a specific function through module notation Fix indented parameter test
Make _Seen_Error_Categories a set
Make clitest setup and teardown conform to naming