### PR TITLE
fix required skipped CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   check-paths:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@4
       - uses: dorny/paths-filter@v3
         id: changes
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
             nondoc:
               - '!**/*.rst'
       - run: echo 'changed=${{ steps.changes.outputs.nondoc }}' >> "$GITHUB_OUTPUT"
+        id: changed
+    outputs:
+      changed: ${{ steps.changed.outputs.changed }}
 
   build-test:
     needs: check-paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,26 @@
 name: Test
 on:
   pull_request:
-    paths-ignore: "*.rst"
   push:
-    # paths-ignore: "*.rst"
     branches: [master, develop]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
-  pre-commit:
+  check-paths:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: pipx run pre-commit run --all-files
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            nondoc:
+              - '!**/*.rst'
+      - run: echo 'changed={{ steps.changes.outputs.nondoc }}' > "$GITHUB_OUTPUT"
 
   build-test:
+    needs: check-paths
+    if: needs.check-paths.outputs.changed == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -41,3 +46,9 @@ jobs:
           python -m pip install --editable .[dev]
       - name: Test with tox
         run: tox -e py
+
+  pass:
+    needs: build-test
+    if: |
+      needs.build-test.result == 'success' && needs.build-test.result == 'skipped'
+    runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,7 @@ jobs:
 
   pass:
     needs: build-test
-    if: |
-      needs.build-test.result == 'success' && needs.build-test.result == 'skipped'
+    if: needs.build-test.result == 'success' || needs.build-test.result == 'skipped'
     runs-on: ubuntu-latest
     steps:
       - name: Curiosity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@de90cc6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           filters: |
             nondoc:
               - '!**/*.rst'
-      - run: echo 'changed={{ steps.changes.outputs.nondoc }}' > "$GITHUB_OUTPUT"
+      - run: echo 'changed=${{ steps.changes.outputs.nondoc }}' > "$GITHUB_OUTPUT"
 
   build-test:
     needs: check-paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,6 @@ jobs:
     if: |
       needs.build-test.result == 'success' && needs.build-test.result == 'skipped'
     runs-on: ubuntu-latest
+    steps:
+      - name: Curiosity
+        run: echo "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ jobs:
   check-paths:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: changes
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6
         id: changes
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,12 @@ jobs:
 
   pass:
     needs: build-test
-    if: needs.build-test.result == 'success' || needs.build-test.result == 'skipped'
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: fail if build-test ran and failed
+        if: ${{ needs.build-test.result == 'failure' }}
+        run: exit 1
       - name: Curiosity
         run: |
           echo "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           filters: |
             nondoc:
               - '!**/*.rst'
-      - run: echo 'changed=${{ steps.changes.outputs.nondoc }}' > "$GITHUB_OUTPUT"
+      - run: echo 'changed=${{ steps.changes.outputs.nondoc }}' >> "$GITHUB_OUTPUT"
 
   build-test:
     needs: check-paths
@@ -57,4 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Curiosity
-        run: echo "$GITHUB_OUTPUT"
+        run: |
+          echo "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,5 +1,0 @@
-[style]
-based_on_style = chromium
-dedent_closing_brackets = True
-coalesce_brackets = True
-continuation_indent_width = 2

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,5 @@
+[style]
+based_on_style = chromium
+dedent_closing_brackets = True
+coalesce_brackets = True
+continuation_indent_width = 2


### PR DESCRIPTION
As @cclauss pointed out in https://github.com/aaronliu0130/cpplint/actions/runs/14286756495/job/40042715929?pr=8, PRs that only change RST files would skip the required build-test workflows, thus merging would be forbidden. This PR introduces a "pass" job that should be required alone instead; it passes if either 1. *every* build-test action has passed 2. the build-test action did not run as the PR only changed RST files.

See the top 3 entries on https://github.com/aaronliu0130/cpplint/actions for how this CI behaves in the 3 cases: Tests run and fail, tests don't run, and tests run and pass.

pre-commit was removed as we have the external pre-commit PR status check now.

I will squash on merge using GitHub's squash feature.