### PR TITLE
GitHub Actions: on workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     # paths-ignore: "*.rst"
     branches: [master, develop]
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
* https://github.com/cpplint/cpplint/pull/358#issuecomment-2781238730

I believe that we can instead just add [workflow_dispatch](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch) which should allow a maintainer to run all tests on a branch.

> [!NOTE] 
> This event will only trigger a workflow run if the workflow file exists on the default branch.