### PR TITLE
chore: Prepare for release v2.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,10 @@
 Changelog
 *********
 
-2.1.0 (2025-04-08)
+2.0.2 (2025-04-08)
 ===========
 
-* Python versions less than 3.9 are no longer supported.
+* Python versions less than 3.9 are no longer supported. (https://github.com/cpplint/cpplint/pull/334)
 * The false positive for indented member initializer lists in namespaces were eradicated. (https://github.com/cpplint/cpplint/pull/353)
 * The warning on non-const references (runtime/references) is now disabled by default pursuant to the May 2020 Google style guide update. (https://github.com/cpplint/cpplint/pull/305)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 *********
 
-2.1.0 (TBA)
+2.1.0 (2025-04-08)
 ===========
 
 * Python versions less than 3.9 are no longer supported.

--- a/cpplint.py
+++ b/cpplint.py
@@ -61,7 +61,7 @@ import xml.etree.ElementTree
 # if empty, use defaults
 _valid_extensions: set[str] = set()
 
-__VERSION__ = "2.0.1"
+__VERSION__ = "2.1.0"
 
 _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]

--- a/cpplint.py
+++ b/cpplint.py
@@ -61,7 +61,7 @@ import xml.etree.ElementTree
 # if empty, use defaults
 _valid_extensions: set[str] = set()
 
-__VERSION__ = "2.1.0"
+__VERSION__ = "2.0.2"
 
 _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]


### PR DESCRIPTION
No other open pull requests.  @aaronliu0130 has landed some critical changes.
* [x] Merge a new pull request that only updates the version number and updates CHANGELOG.rst.
* [x] Go to https://github.com/cpplint/cpplint/releases/new
* [x] Put in the NEW version number.
* [x] Click the Generate release notes button
* [x] Click the Save draft button and ask other maintainers to review.
* [ ] Ship it and check https://pypi.org/project/cpplint after a few minutes.

Draft release:  https://github.com/cpplint/cpplint/releases/edit/untagged-bac3df867046406901f0