### PR TITLE
fix(readability/casting): noexcept *functions

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -6720,7 +6720,7 @@ def CheckCasts(filename, clean_lines, linenum, error):
     else:
         # Check pointer casts for other than string constants
         CheckCStyleCast(
-            filename, clean_lines, linenum, "reinterpret_cast", r"\((\w+\s?\*+\s?)\)", error
+            filename, clean_lines, linenum, "reinterpret_cast", r"(?<!\))\((\w+\s?\*+\s?)\)", error
         )
 
     # In addition, we look for people taking the address of a cast.  This
@@ -6782,6 +6782,7 @@ def CheckCasts(filename, clean_lines, linenum, error):
             )
 
 
+# TODO(aaronliu0130): refactor to avoid running checks already run through previous call of this
 def CheckCStyleCast(filename, clean_lines, linenum, cast_type, pattern, error):
     """Checks for a C-style cast by looking for the pattern.
 
@@ -6820,10 +6821,10 @@ def CheckCStyleCast(filename, clean_lines, linenum, cast_type, pattern, error):
     if context.endswith((" operator++", " operator--", "::operator++", "::operator--")):
         return False
 
-    # A single unnamed argument for a function tends to look like old style cast;
-    # so do function pointers. If we see those, don't issue warnings for deprecated casts.
+    # A single unnamed argument for a function tends to look like old style cast.
+    # If we see those, don't issue warnings for deprecated casts.
     remainder = line[match.end(0) :]
-    if re.match(r"^\s*(?:;|(?:const|throw|final|override|noexcept)\b|[=>{),]|->)", remainder):
+    if re.match(r"^\s*(?:;|(?:const|throw|final|override)\b|[=>{),]|->)", remainder):
         return False
 
     # At this point, all that should be left is actual casts.

--- a/cpplint.py
+++ b/cpplint.py
@@ -6820,7 +6820,7 @@ def CheckCStyleCast(filename, clean_lines, linenum, cast_type, pattern, error):
     if context.endswith((" operator++", " operator--", "::operator++", "::operator--")):
         return False
 
-    # A single unnamed argument for a function tend to look like old style cast;
+    # A single unnamed argument for a function tends to look like old style cast;
     # so do function pointers. If we see those, don't issue warnings for deprecated casts.
     remainder = line[match.end(0) :]
     if re.match(r"^\s*(?:;|(?:const|throw|final|override|noexcept)\b|[=>{),]|->)", remainder):

--- a/cpplint.py
+++ b/cpplint.py
@@ -6820,10 +6820,10 @@ def CheckCStyleCast(filename, clean_lines, linenum, cast_type, pattern, error):
     if context.endswith((" operator++", " operator--", "::operator++", "::operator--")):
         return False
 
-    # A single unnamed argument for a function tends to look like old style cast.
-    # If we see those, don't issue warnings for deprecated casts.
+    # A single unnamed argument for a function tend to look like old style cast;
+    # so do function pointers. If we see those, don't issue warnings for deprecated casts.
     remainder = line[match.end(0) :]
-    if re.match(r"^\s*(?:;|const\b|throw\b|final\b|override\b|[=>{),]|->)", remainder):
+    if re.match(r"^\s*(?:;|(?:const|throw|final|override|noexcept)\b|[=>{),]|->)", remainder):
         return False
 
     # At this point, all that should be left is actual casts.

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1107,6 +1107,7 @@ class TestCpplint(CpplintTestBase):
         self.TestLint("void Function(bool(FunctionPointerArg)()) {}", "")
         self.TestLint("typedef set<int64_t, bool(*)(int64_t, int64_t)> SortedIdSet", "")
         self.TestLint("bool TraverseNode(T *Node, bool(VisitorBase:: *traverse) (T *t)) {}", "")
+        self.TestLint("void (*execute_)(operation_base*) noexcept(may_throw());", "")
 
     # The second parameter to a gMock method definition is a function signature
     # that often looks like a bad cast but should not picked up by lint.

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1050,17 +1050,20 @@ class TestCpplint(CpplintTestBase):
             "Use static_cast<int>(...) instead"
             "  [readability/casting] [4]",
         )
-
         self.TestLint(
             '(char *) "foo"',
             "Using C-style cast.  Use const_cast<char *>(...) instead  [readability/casting] [4]",
         )
-
         self.TestLint(
             "(int*)foo",
             "Using C-style cast.  "
             "Use reinterpret_cast<int*>(...) instead"
             "  [readability/casting] [4]",
+        )
+        self.TestLint(
+            "(Type**) noexcept(f())",
+            "Using C-style cast.  "
+            "Use reinterpret_cast<Type**>(...) instead  [readability/casting] [4]",
         )
 
         # Checks for false positives...


### PR DESCRIPTION
Fixes #354

this shall be squashed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of deprecated C-style pointer casts.
  * Reduced false-positive warnings for function-pointer declarations involving `noexcept`.

* **Tests**
  * Added regression coverage for pointer casts and `noexcept` function-pointer syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->