### PR TITLE
fix(regen-defs): Fix globs and clean tempfiles on INT, TERM

### DIFF
--- a/regen-defs.zsh
+++ b/regen-defs.zsh
@@ -30,7 +30,7 @@ for folder in $folders; do
     trap cleanup INT TERM
 
     # Execute the command and capture stdout and stderr
-    uv run "$cpplint" ${(~)cmd} > "$stdout_file" 2> "$stderr_file"
+    eval uv run "$cpplint" $cmd > "$stdout_file" 2> "$stderr_file"
     ret_code=$?
 
     # Count the number of lines in stdout

--- a/regen-defs.zsh
+++ b/regen-defs.zsh
@@ -30,7 +30,7 @@ for folder in $folders; do
     trap cleanup INT TERM
 
     # Execute the command and capture stdout and stderr
-    eval uv run "$cpplint" $cmd > "$stdout_file" 2> "$stderr_file"
+    uv run "$cpplint" ${(~)cmd} > "$stdout_file" 2> "$stderr_file"
     ret_code=$?
 
     # Count the number of lines in stdout

--- a/regen-defs.zsh
+++ b/regen-defs.zsh
@@ -23,8 +23,14 @@ for folder in $folders; do
     stdout_file=$(mktemp)
     stderr_file=$(mktemp)
 
+    # Cleanup on interruption
+    cleanup() {
+      rm "$stdout_file" "$stderr_file"
+    }
+    trap cleanup INT TERM
+
     # Execute the command and capture stdout and stderr
-    uv run "$cpplint" $cmd > "$stdout_file" 2> "$stderr_file"
+    eval uv run "$cpplint" $cmd > "$stdout_file" 2> "$stderr_file"
     ret_code=$?
 
     # Count the number of lines in stdout
@@ -42,7 +48,7 @@ for folder in $folders; do
     } > "$file"
 
     # Clean up temporary files
-    rm "$stdout_file" "$stderr_file"
+    cleanup
   done
   cd ..
 done

--- a/regen-defs.zsh
+++ b/regen-defs.zsh
@@ -26,6 +26,7 @@ for folder in $folders; do
     # Cleanup on interruption
     cleanup() {
       rm "$stdout_file" "$stderr_file"
+      exit $((128 + $1))
     }
     trap cleanup INT TERM
 

--- a/regen-defs.zsh
+++ b/regen-defs.zsh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 
 # Input the path of cpplint here
-cpplint="$HOME/Documents/cpplint/cpplint.py"
+cpplint="$HOME/Projects/cpplint/cpplint.py"
 
 cd samples/ || exit 74  # EX_IOERROR
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interruption handling so temporary output files are reliably cleaned up when the generation/linting process is stopped.

* **Refactor**
  * Centralized temporary-file cleanup into a single routine and aligned command execution with the updated cleanup flow.
  * Updated the configured lint tool path to use the correct project directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->