### PR TITLE
change shebang to python3

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #

--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
Some distros, like Debian, have been moving in the direction of dropping /usr/bin/python by default and only providing /usr/bin/python3.  This causes the cpplint tools to fail by default when run with system versions. Switch over to python3 to try and work out of the box by default more.