### PR TITLE
enhance_using_directives_267

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -308,8 +308,14 @@ _ERROR_CATEGORIES = [
     "build/include_order",
     "build/include_what_you_use",
     "build/namespaces_headers",
-    "build/namespaces_literals",
-    "build/namespaces",
+    "build/namespaces/header/block/literals",
+    "build/namespaces/header/block/nonliterals",
+    "build/namespaces/header/namespace/literals",
+    "build/namespaces/header/namespace/nonliterals",
+    "build/namespaces/source/block/literals",
+    "build/namespaces/source/block/nonliterals",
+    "build/namespaces/source/namespace/literals",
+    "build/namespaces/source/namespace/nonliterals",
     "build/printf_format",
     "build/storage_class",
     "legal/copyright",
@@ -6021,22 +6027,20 @@ def CheckLanguage(
         )
 
     if re.search(r"\busing namespace\b", line):
-        if re.search(r"\bliterals\b", line):
-            error(
-                filename,
-                linenum,
-                "build/namespaces_literals",
-                5,
-                "Do not use namespace using-directives.  Use using-declarations instead.",
-            )
-        else:
-            error(
-                filename,
-                linenum,
-                "build/namespaces",
-                5,
-                "Do not use namespace using-directives.  Use using-declarations instead.",
-            )
+        is_literals = re.search(r"\bliterals\b", line) is not None
+        is_header = not _IsSourceExtension(file_extension)
+        file_type = "header" if is_header else "source"
+
+        is_block_scope = nesting_state.stack or not line.startswith("using namespace")
+
+        scope_type = "block" if is_block_scope else "namespace"
+        literal_type = "literals" if is_literals else "nonliterals"
+
+        specific_category = f"build/namespaces/{file_type}/{scope_type}/{literal_type}"
+
+        error(filename, linenum, specific_category, 5,
+              "Do not use namespace using-directives.  "
+              "Use using-declarations instead.")
 
     # Detect variable-length arrays.
     match = re.match(r"\s*(.+::)?(\w+) [a-z]\w*\[(.+)];", line)

--- a/cpplint.py
+++ b/cpplint.py
@@ -6041,7 +6041,7 @@ def CheckLanguage(
 
         # Check for the block scope for multi line blocks.
         # Check if the line starts with the using directive as a hueristic in case it's all one line
-        is_block_scope = nesting_state.IsInBlockScope() and not line.startswith("using namespace")
+        is_block_scope = nesting_state.InBlockScope() and not line.startswith("using namespace")
 
         scope_type = "block" if is_block_scope else "namespace"
         literal_type = "literals" if is_literals else "nonliterals"

--- a/cpplint.py
+++ b/cpplint.py
@@ -6041,7 +6041,7 @@ def CheckLanguage(
 
         # Check for the block scope for multi line blocks.
         # Check if the line starts with the using directive as a hueristic in case it's all one line
-        is_block_scope = nesting_state.InBlockScope() and not line.startswith("using namespace")
+        is_block_scope = nesting_state.InBlockScope() or not line.startswith("using namespace")
 
         scope_type = "block" if is_block_scope else "namespace"
         literal_type = "literals" if is_literals else "nonliterals"

--- a/cpplint.py
+++ b/cpplint.py
@@ -941,6 +941,14 @@ _SED_FIXUPS = {
     "Missing space after ,": r"s/,\([^ ]\)/, \1/g",
 }
 
+ # Used for backwards compatibility and ease of use
+_FILTER_SHORTCUTS = {
+    "build/namespaces_literals" : ["build/namespaces/header/block/literals",
+                                   "build/namespaces/header/namespace/literals",
+                                   "build/namespaces/source/block/literals",
+                                   "build/namespaces/source/namespace/literals"]
+}
+
 # The root directory used for deriving header guard CPP variable.
 # This is set by --root flag.
 _root = None
@@ -1463,7 +1471,12 @@ class _CppLintState:
         for filt in filters.split(","):
             clean_filt = filt.strip()
             if clean_filt:
-                self.filters.append(clean_filt)
+                if len(clean_filt) > 1 and clean_filt[1:] in _FILTER_SHORTCUTS:
+                    starting_char = clean_filt[0]
+                    new_filters = [starting_char + x for x in _FILTER_SHORTCUTS[clean_filt[1:]]]
+                    self.filters.extend(new_filters)
+                else:
+                    self.filters.append(clean_filt)
         for filt in self.filters:
             if not filt.startswith(("+", "-")):
                 msg = f"Every filter in --filters must start with + or - ({filt} does not)"
@@ -6039,8 +6052,8 @@ def CheckLanguage(
         is_header = not _IsSourceExtension(file_extension)
         file_type = "header" if is_header else "source"
 
-        # Check for the block scope for multi line blocks.
-        # Check if the line starts with the using directive as a hueristic in case it's all one line
+        # Check for the block scope for multiline blocks.
+        # Check if the line starts with the using directive as a heuristic in case it's all one line
         is_block_scope = nesting_state.InBlockScope() or not line.startswith("using namespace")
 
         scope_type = "block" if is_block_scope else "namespace"

--- a/cpplint.py
+++ b/cpplint.py
@@ -6038,9 +6038,13 @@ def CheckLanguage(
 
         specific_category = f"build/namespaces/{file_type}/{scope_type}/{literal_type}"
 
-        error(filename, linenum, specific_category, 5,
-              "Do not use namespace using-directives.  "
-              "Use using-declarations instead.")
+        error(
+            filename,
+            linenum,
+            specific_category,
+            5,
+            "Do not use namespace using-directives.  Use using-declarations instead.",
+        )
 
     # Detect variable-length arrays.
     match = re.match(r"\s*(.+::)?(\w+) [a-z]\w*\[(.+)];", line)

--- a/cpplint.py
+++ b/cpplint.py
@@ -3293,6 +3293,14 @@ class NestingState:
         """
         return self.stack and self.stack[-1].inline_asm != _NO_ASM
 
+    def InBlockScope(self):
+        """Check if we are currently one level inside a block scope.
+
+        Returns:
+          True if top of the stack is a block scope, False otherwise.
+        """
+        return len(self.stack) > 0 and not isinstance(self.stack[-1], _NamespaceInfo)
+
     def InTemplateArgumentList(self, clean_lines, linenum, pos):
         """Check if current position is inside template argument list.
 
@@ -6031,7 +6039,9 @@ def CheckLanguage(
         is_header = not _IsSourceExtension(file_extension)
         file_type = "header" if is_header else "source"
 
-        is_block_scope = nesting_state.stack or not line.startswith("using namespace")
+        # Check for the block scope for multi line blocks.
+        # Check if the line starts with the using directive as a hueristic in case it's all one line
+        is_block_scope = nesting_state.IsInBlockScope() and not line.startswith("using namespace")
 
         scope_type = "block" if is_block_scope else "namespace"
         literal_type = "literals" if is_literals else "nonliterals"

--- a/cpplint.py
+++ b/cpplint.py
@@ -941,12 +941,14 @@ _SED_FIXUPS = {
     "Missing space after ,": r"s/,\([^ ]\)/, \1/g",
 }
 
- # Used for backwards compatibility and ease of use
+# Used for backwards compatibility and ease of use
 _FILTER_SHORTCUTS = {
-    "build/namespaces_literals" : ["build/namespaces/header/block/literals",
-                                   "build/namespaces/header/namespace/literals",
-                                   "build/namespaces/source/block/literals",
-                                   "build/namespaces/source/namespace/literals"]
+    "build/namespaces_literals": [
+        "build/namespaces/header/block/literals",
+        "build/namespaces/header/namespace/literals",
+        "build/namespaces/source/block/literals",
+        "build/namespaces/source/namespace/literals",
+    ]
 }
 
 # The root directory used for deriving header guard CPP variable.

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3640,7 +3640,7 @@ class TestCpplint(CpplintTestBase):
             assert (
                 error_collector.Results().count(
                     "Do not use namespace using-directives.  Use using-declarations instead.  "
-                    "[build/namespaces] [5]"
+                    "[build/namespaces/source/namespace/nonliterals] [5]"
                 )
                 == 1
             )
@@ -3648,20 +3648,6 @@ class TestCpplint(CpplintTestBase):
         DoTest(self, ["using namespace foo;"])
         DoTest(self, ["", "", "", "using namespace foo;"])
         DoTest(self, ["// hello", "using namespace foo;"])
-
-    def testUsingLiteralsNamespaces(self):
-        self.TestLint(
-            "using namespace std::literals;",
-            "Do not use namespace"
-            " using-directives.  Use using-declarations instead."
-            "  [build/namespaces_literals] [5]",
-        )
-        self.TestLint(
-            "using namespace std::literals::chrono_literals;",
-            "Do"
-            " not use namespace using-directives.  Use using-declarations instead."
-            "  [build/namespaces_literals] [5]",
-        )
 
     def testNewlineAtEOF(self):
         def DoTest(self, data, is_missing_eof):
@@ -4202,6 +4188,53 @@ class TestCpplint(CpplintTestBase):
             )
             == 0
         )
+
+    def testUsingNamespacesGranular(self):
+        """Test granular using namespace checks for different contexts."""
+
+        self.TestLanguageRulesCheck("foo.h", "using namespace std;",
+                                    "Do not use namespace using-directives.  "
+                                    "Use using-declarations instead."
+                                    "  [build/namespaces/header/namespace/nonliterals] [5]")
+
+        self.TestLanguageRulesCheck("foo.h", "using namespace std::chrono::literals;",
+                                    "Do not use namespace using-directives.  "
+                                    "Use using-declarations instead."
+                                    "  [build/namespaces/header/namespace/literals] [5]")
+
+        self.TestLanguageRulesCheck(
+            "foo.cc", "using namespace std;",
+            "Do not use namespace using-directives.  "
+            "Use using-declarations instead."
+            "  [build/namespaces/source/namespace/nonliterals] [5]")
+
+        self.TestLanguageRulesCheck(
+            "foo.cc", "using namespace std::chrono::literals;",
+            "Do not use namespace using-directives.  "
+            "Use using-declarations instead."
+            "  [build/namespaces/source/namespace/literals] [5]")
+
+        self.TestLanguageRulesCheck("foo.h", "{ using namespace std; }",
+                                    "Do not use namespace using-directives.  "
+                                    "Use using-declarations instead."
+                                    "  [build/namespaces/header/block/nonliterals] [5]")
+
+        self.TestLanguageRulesCheck("foo.h", "{ using namespace std::chrono::literals; }",
+                                    "Do not use namespace using-directives.  "
+                                    "Use using-declarations instead."
+                                    "  [build/namespaces/header/block/literals] [5]")
+
+        self.TestLanguageRulesCheck(
+            "foo.cc", "{ using namespace std; }",
+            "Do not use namespace using-directives.  "
+            "Use using-declarations instead."
+            "  [build/namespaces/source/block/nonliterals] [5]")
+
+        self.TestLanguageRulesCheck(
+            "foo.cc", "{ using namespace std::chrono::literals; }",
+            "Do not use namespace using-directives.  "
+            "Use using-declarations instead."
+            "  [build/namespaces/source/block/literals] [5]")
 
     def testComma(self):
         self.TestLint("a = f(1,2);", "Missing space after ,  [whitespace/comma] [3]")

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4192,49 +4192,69 @@ class TestCpplint(CpplintTestBase):
     def testUsingNamespacesGranular(self):
         """Test granular using namespace checks for different contexts."""
 
-        self.TestLanguageRulesCheck("foo.h", "using namespace std;",
-                                    "Do not use namespace using-directives.  "
-                                    "Use using-declarations instead."
-                                    "  [build/namespaces/header/namespace/nonliterals] [5]")
-
-        self.TestLanguageRulesCheck("foo.h", "using namespace std::chrono::literals;",
-                                    "Do not use namespace using-directives.  "
-                                    "Use using-declarations instead."
-                                    "  [build/namespaces/header/namespace/literals] [5]")
-
         self.TestLanguageRulesCheck(
-            "foo.cc", "using namespace std;",
+            "foo.h",
+            "using namespace std;",
             "Do not use namespace using-directives.  "
             "Use using-declarations instead."
-            "  [build/namespaces/source/namespace/nonliterals] [5]")
+            "  [build/namespaces/header/namespace/nonliterals] [5]",
+        )
 
         self.TestLanguageRulesCheck(
-            "foo.cc", "using namespace std::chrono::literals;",
+            "foo.h",
+            "using namespace std::chrono::literals;",
             "Do not use namespace using-directives.  "
             "Use using-declarations instead."
-            "  [build/namespaces/source/namespace/literals] [5]")
-
-        self.TestLanguageRulesCheck("foo.h", "{ using namespace std; }",
-                                    "Do not use namespace using-directives.  "
-                                    "Use using-declarations instead."
-                                    "  [build/namespaces/header/block/nonliterals] [5]")
-
-        self.TestLanguageRulesCheck("foo.h", "{ using namespace std::chrono::literals; }",
-                                    "Do not use namespace using-directives.  "
-                                    "Use using-declarations instead."
-                                    "  [build/namespaces/header/block/literals] [5]")
+            "  [build/namespaces/header/namespace/literals] [5]",
+        )
 
         self.TestLanguageRulesCheck(
-            "foo.cc", "{ using namespace std; }",
+            "foo.cc",
+            "using namespace std;",
             "Do not use namespace using-directives.  "
             "Use using-declarations instead."
-            "  [build/namespaces/source/block/nonliterals] [5]")
+            "  [build/namespaces/source/namespace/nonliterals] [5]",
+        )
 
         self.TestLanguageRulesCheck(
-            "foo.cc", "{ using namespace std::chrono::literals; }",
+            "foo.cc",
+            "using namespace std::chrono::literals;",
             "Do not use namespace using-directives.  "
             "Use using-declarations instead."
-            "  [build/namespaces/source/block/literals] [5]")
+            "  [build/namespaces/source/namespace/literals] [5]",
+        )
+
+        self.TestLanguageRulesCheck(
+            "foo.h",
+            "{ using namespace std; }",
+            "Do not use namespace using-directives.  "
+            "Use using-declarations instead."
+            "  [build/namespaces/header/block/nonliterals] [5]",
+        )
+
+        self.TestLanguageRulesCheck(
+            "foo.h",
+            "{ using namespace std::chrono::literals; }",
+            "Do not use namespace using-directives.  "
+            "Use using-declarations instead."
+            "  [build/namespaces/header/block/literals] [5]",
+        )
+
+        self.TestLanguageRulesCheck(
+            "foo.cc",
+            "{ using namespace std; }",
+            "Do not use namespace using-directives.  "
+            "Use using-declarations instead."
+            "  [build/namespaces/source/block/nonliterals] [5]",
+        )
+
+        self.TestLanguageRulesCheck(
+            "foo.cc",
+            "{ using namespace std::chrono::literals; }",
+            "Do not use namespace using-directives.  "
+            "Use using-declarations instead."
+            "  [build/namespaces/source/block/literals] [5]",
+        )
 
     def testComma(self):
         self.TestLint("a = f(1,2);", "Missing space after ,  [whitespace/comma] [3]")

--- a/samples/silly-sample/filters.def
+++ b/samples/silly-sample/filters.def
@@ -13,7 +13,7 @@ src/sillycode.cpp:1:  Include the directory when naming header files  [build/inc
 src/sillycode.cpp:2:  <ratio> is an unapproved C++11 header.  [build/c++11] [5]
 src/sillycode.cpp:3:  Found C system header after other header. Should be: sillycode.h, c system, c++ system, other.  [build/include_order] [4]
 src/sillycode.cpp:4:  Found C system header after other header. Should be: sillycode.h, c system, c++ system, other.  [build/include_order] [4]
-src/sillycode.cpp:5:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
+src/sillycode.cpp:5:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/nonliterals] [5]
 src/sillycode.cpp:40:  If/else bodies with multiple statements require braces  [readability/braces] [4]
 src/sillycode.cpp:66:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [4]
 src/sillycode.cpp:76:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [4]

--- a/samples/silly-sample/includeorder_cfirst.def
+++ b/samples/silly-sample/includeorder_cfirst.def
@@ -11,7 +11,7 @@ src/sillycode.cpp:2:  Should have a space between // and comment  [whitespace/co
 src/sillycode.cpp:2:  <ratio> is an unapproved C++11 header.  [build/c++11] [5]
 src/sillycode.cpp:3:  Found other system header after other header. Should be: sillycode.h, c system, c++ system, other.  [build/include_order] [4]
 src/sillycode.cpp:4:  Found other system header after other header. Should be: sillycode.h, c system, c++ system, other.  [build/include_order] [4]
-src/sillycode.cpp:5:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
+src/sillycode.cpp:5:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/nonliterals] [5]
 src/sillycode.cpp:8:  public: should be indented +1 space inside class Date  [whitespace/indent] [3]
 src/sillycode.cpp:15:  { should almost always be at the end of the previous line  [whitespace/braces] [4]
 src/sillycode.cpp:39:  { should almost always be at the end of the previous line  [whitespace/braces] [4]

--- a/samples/silly-sample/sed.def
+++ b/samples/silly-sample/sed.def
@@ -15,7 +15,7 @@ sed -i '249s/\([^ ]\){/\1 {/' src/sillycode.cpp # Missing space before {  [white
 # src/sillycode.cpp:2:  "<ratio> is an unapproved C++11 header."  [build/c++11] [5]
 # src/sillycode.cpp:3:  "Found C system header after other header. Should be: sillycode.h, c system, c++ system, other."  [build/include_order] [4]
 # src/sillycode.cpp:4:  "Found C system header after other header. Should be: sillycode.h, c system, c++ system, other."  [build/include_order] [4]
-# src/sillycode.cpp:5:  "Do not use namespace using-directives.  Use using-declarations instead."  [build/namespaces] [5]
+# src/sillycode.cpp:5:  "Do not use namespace using-directives.  Use using-declarations instead."  [build/namespaces/source/namespace/nonliterals] [5]
 # src/sillycode.cpp:8:  "public: should be indented +1 space inside class Date"  [whitespace/indent] [3]
 # src/sillycode.cpp:15:  "{ should almost always be at the end of the previous line"  [whitespace/braces] [4]
 # src/sillycode.cpp:39:  "{ should almost always be at the end of the previous line"  [whitespace/braces] [4]

--- a/samples/silly-sample/simple.def
+++ b/samples/silly-sample/simple.def
@@ -12,7 +12,7 @@ src/sillycode.cpp:2:  Should have a space between // and comment  [whitespace/co
 src/sillycode.cpp:2:  <ratio> is an unapproved C++11 header.  [build/c++11] [5]
 src/sillycode.cpp:3:  Found C system header after other header. Should be: sillycode.h, c system, c++ system, other.  [build/include_order] [4]
 src/sillycode.cpp:4:  Found C system header after other header. Should be: sillycode.h, c system, c++ system, other.  [build/include_order] [4]
-src/sillycode.cpp:5:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
+src/sillycode.cpp:5:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/nonliterals] [5]
 src/sillycode.cpp:8:  public: should be indented +1 space inside class Date  [whitespace/indent] [3]
 src/sillycode.cpp:15:  { should almost always be at the end of the previous line  [whitespace/braces] [4]
 src/sillycode.cpp:39:  { should almost always be at the end of the previous line  [whitespace/braces] [4]


### PR DESCRIPTION
# Description
Enhance the using directives check by adding more granularity to the warnings.
The warnings are split into multiple categories
1. block/namespace scope
2. source/header file
3. literal/nonliteral namespace

Possible filter combinations would look like the following

1. Google: None
2. CppCoreGuidelines
    1. -build/namespaces/header/block
    2. -build/namespaces/source
3. Like CppCoreGuidlines, but disallow non-literal namespaces in source files at namespace scope
    1. -build/namespaces/header/block
    2. -build/namespaces/source/block
    3. -build/namespaces/source/namespace/literal

# Tests

## Unit Tests
```
python3 cpplint_unittest.py
python3 cpplint_clitest.py
```

## Configuration tests
my_test.h
```
// Copyright 2025 Geoffrey Viola

#ifndef MY_TEST_H_
#define MY_TEST_H_

using namespace std;
using namespace std::chrono::literals;

void foo() {
  using namespace std;
  using namespace std::chrono::literals;
}

#endif  // MY_TEST_H_
```

my_test.cc
```
// Copyright 2025 Geoffrey Viola

using namespace std;
using namespace std::chrono::literals;

void foo() {
  using namespace std;
  using namespace std::chrono::literals;
}
```

### Tests
```
python3 cpplint.py my_test.cc
my_test.cc:3:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/nonliterals] [5]
my_test.cc:4:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/literals] [5]
my_test.cc:7:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/block/nonliterals] [5]
my_test.cc:8:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/block/literals] [5]
Done processing my_test.cc
Total errors found: 4

python3 cpplint.py my_test.h
my_test.h:6:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/namespace/nonliterals] [5]
my_test.h:7:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/namespace/literals] [5]
my_test.h:10:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/block/nonliterals] [5]
my_test.h:11:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/block/literals] [5]
Done processing my_test.h
Total errors found: 4

python3 cpplint.py --filter=-build/namespaces my_test.h
Done processing my_test.h
python3 cpplint.py --filter=-build/namespaces my_test.cc
Done processing my_test.cc

python3 cpplint.py --filter=-build/namespaces/source my_test.h
my_test.h:6:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/namespace/nonliterals] [5]
my_test.h:7:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/namespace/literals] [5]
my_test.h:10:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/block/nonliterals] [5]
my_test.h:11:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/block/literals] [5]
Done processing my_test.h
Total errors found: 4
python3 cpplint.py --filter=-build/namespaces/source my_test.cc
Done processing my_test.cc

python3 cpplint.py --filter=-build/namespaces/source/block my_test.h
my_test.h:6:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/namespace/nonliterals] [5]
my_test.h:7:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/namespace/literals] [5]
my_test.h:10:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/block/nonliterals] [5]
my_test.h:11:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/block/literals] [5]
Done processing my_test.h
Total errors found: 4
python3 cpplint.py --filter=-build/namespaces/source/block my_test.cc
my_test.cc:3:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/nonliterals] [5]
my_test.cc:4:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/literals] [5]
Done processing my_test.cc
Total errors found: 2

python3 cpplint.py --filter=-build/namespaces/source/block/literals my_test.h
my_test.h:6:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/namespace/nonliterals] [5]
my_test.h:7:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/namespace/literals] [5]
my_test.h:10:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/block/nonliterals] [5]
my_test.h:11:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/header/block/literals] [5]
Done processing my_test.h
Total errors found: 4
python3 cpplint.py --filter=-build/namespaces/source/block/literals my_test.cc
my_test.cc:3:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/nonliterals] [5]
my_test.cc:4:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/namespace/literals] [5]
my_test.cc:7:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces/source/block/nonliterals] [5]
Done processing my_test.cc
Total errors found: 3
```

# Issues
https://github.com/cpplint/cpplint/issues/267