### PR TITLE
chore(metadata): Use just an SPDX identifier for license indication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=61.2" ]
+requires = [ "setuptools>=77" ]
 
 [project]
 name = "cpplint"
@@ -19,15 +19,15 @@ authors = [
   { name = "Andrew Davis", email = "theandrewdavis@gmail.com" },
   { name = "cpplint developers" },
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "Intended Audience :: End Users/Desktop",
-  "License :: Freely Distributable",
   "Natural Language :: English",
   "Programming Language :: C++",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cpplint"
 description = "Check C++ files configurably against Google's style guide"
 readme = "README.rst"
 keywords = [ "c++", "cpp", "google style", "lint" ]
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 maintainers = [
   { name = "Aaron Liu", email = "aaronliu0130@gmail.com" },
   { name = "Christian Clauss", email = "cclauss@me.com" },
@@ -25,7 +25,6 @@ classifiers = [
   "Environment :: Console",
   "Intended Audience :: End Users/Desktop",
   "License :: Freely Distributable",
-  "License :: OSI Approved :: BSD License",
   "Natural Language :: English",
   "Programming Language :: C++",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Implement PEP 639/Core Metadata Specifications 2.4, approved August 2024; see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.