### PR TITLE
fix(nolint): skip unopened NOLINTEND blocks that specify a category

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -1157,7 +1157,11 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
                 _error_suppressions.StartBlockSuppression(category, linenum)
         elif no_lint_type == "END":
             if not _error_suppressions.HasOpenBlock():
-                error(filename, linenum, "readability/nolint", 5, "Not in a NOLINT block")
+                if matched.group(2) not in (None, "(*)"):
+                    # Has category; probably a clang-tidy rule. Safer to ignore.
+                    pass
+                else:
+                    error(filename, linenum, "readability/nolint", 5, "Not in a NOLINT block")
 
             def ProcessCategory(category):
                 if category is not None:

--- a/cpplint.py
+++ b/cpplint.py
@@ -1157,11 +1157,11 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
                 _error_suppressions.StartBlockSuppression(category, linenum)
         elif no_lint_type == "END":
             if not _error_suppressions.HasOpenBlock():
-                if matched.group(2) not in (None, "(*)"):
+                if matched.group(2) in (None, "(*)"):
+                    error(filename, linenum, "readability/nolint", 5, "Not in a NOLINT block")
+                else:
                     # Has category; probably a clang-tidy rule. Safer to ignore.
                     pass
-                else:
-                    error(filename, linenum, "readability/nolint", 5, "Not in a NOLINT block")
 
             def ProcessCategory(category):
                 if category is not None:

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -773,6 +773,24 @@ class TestCpplint(CpplintTestBase):
             == "NOLINT categories not supported in block END: readability/casting  "
             "[readability/nolint] [5]"
         )
+        # categories for external tools like clang-tidy should be ignored
+        error_collector = ErrorCollector(self.assertTrue)
+        cpplint.ProcessFileData(
+            "test.cc",
+            "cc",
+            [
+                "// Copyright 2026 Space Dot",
+                "// NOLINTBEGIN(clang-analyzer-core.uninitialized.UndefReturn)",
+                "long c = 418;",
+                "// NOLINTEND(clang-analyzer-core.uninitialized.UndefReturn)",
+                "",
+            ],
+            error_collector,
+        )
+        assert (
+            error_collector.Results()
+            == "Use int16_t/int64_t/etc, rather than the C type long  [runtime/int] [4]"
+        )
         # nested NOLINTBEGIN is not allowed
         error_collector = ErrorCollector(self.assertTrue)
         cpplint.ProcessFileData(


### PR DESCRIPTION
these are often for external tools like clang-tidy instead

Should fix #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted handling of NOLINT END blocks so an error is only reported when no category is specified; END with an explicit category is quietly ignored.

* **Tests**
  * Added a test to confirm NOLINTBEGIN blocks that specify external tool categories do not suppress unrelated warnings, ensuring suppression behavior matches expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->