### PR TITLE
Fix IndexError in constructor args with bitwise operators

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -920,6 +920,10 @@ _SEARCH_C_FILE = re.compile(
 # Match string that indicates we're working on a Linux Kernel file.
 _SEARCH_KERNEL_FILE = re.compile(r"\b(?:LINT_KERNEL_FILE)")
 
+# Operator sequences beginning with '<' (used to strip before counting angle brackets).
+# Longer sequences must come first so '<<=' is not partially matched as '<<'.
+_LANGLE_OPS_RE = re.compile(r"<<=|<=|<<")
+
 # Commands for sed to fix the problem
 _SED_FIXUPS = {
     "Remove spaces around =": r"s/ = /=/",
@@ -3981,7 +3985,6 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
         # characters do not trigger the joining loop (condition is
         # count('<') > count('>')), and stripping '>>' would break nested
         # template types such as vector<vector<int>>.
-        _LANGLE_OPS_RE = re.compile(r"<<=|<=|<<")
         i = 0
         while i < len(constructor_args):
             constructor_arg = constructor_args[i]

--- a/cpplint.py
+++ b/cpplint.py
@@ -3972,11 +3972,17 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
         i = 0
         while i < len(constructor_args):
             constructor_arg = constructor_args[i]
-            while constructor_arg.count("<") > constructor_arg.count(">") or constructor_arg.count(
+            # Strip << (bitwise left-shift) before counting angle brackets, to
+            # avoid confusing shift operators with unmatched template brackets.
+            cleaned_arg = re.sub(r"<<", "", constructor_arg)
+            while cleaned_arg.count("<") > cleaned_arg.count(">") or cleaned_arg.count(
                 "("
-            ) > constructor_arg.count(")"):
+            ) > cleaned_arg.count(")"):
+                if i + 1 >= len(constructor_args):
+                    break
                 constructor_arg += "," + constructor_args[i + 1]
                 del constructor_args[i + 1]
+                cleaned_arg = re.sub(r"<<", "", constructor_arg)
             constructor_args[i] = constructor_arg
             i += 1
 

--- a/cpplint.py
+++ b/cpplint.py
@@ -3968,13 +3968,20 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
             constructor_args = explicit_constructor_match.group(2).split(",")
 
         # collapse arguments so that commas in template parameter lists and function
-        # argument parameter lists don't split arguments in two
+        # argument parameter lists don't split arguments in two.
+        # Strip operator sequences that begin with '<' before counting angle
+        # brackets, to avoid confusing operators with unmatched template
+        # brackets.  Longer sequences must come first so that '<<=' is not
+        # partially matched as '<<' leaving a stray '='.
+        # Note: '>>' and '>=' are intentionally left alone because extra '>'
+        # characters do not trigger the joining loop (condition is
+        # count('<') > count('>')), and stripping '>>' would break nested
+        # template types such as vector<vector<int>>.
+        _LANGLE_OPS_RE = re.compile(r"<<=|<=|<<")
         i = 0
         while i < len(constructor_args):
             constructor_arg = constructor_args[i]
-            # Strip << (bitwise left-shift) before counting angle brackets, to
-            # avoid confusing shift operators with unmatched template brackets.
-            cleaned_arg = re.sub(r"<<", "", constructor_arg)
+            cleaned_arg = _LANGLE_OPS_RE.sub("", constructor_arg)
             while cleaned_arg.count("<") > cleaned_arg.count(">") or cleaned_arg.count(
                 "("
             ) > cleaned_arg.count(")"):
@@ -3982,7 +3989,7 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
                     break
                 constructor_arg += "," + constructor_args[i + 1]
                 del constructor_args[i + 1]
-                cleaned_arg = re.sub(r"<<", "", constructor_arg)
+                cleaned_arg = _LANGLE_OPS_RE.sub("", constructor_arg)
             constructor_args[i] = constructor_arg
             i += 1
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1808,6 +1808,15 @@ class TestCpplint(CpplintTestBase):
           };""",
                 "",
             )
+            # No crash or warning for constructors with << (bitwise shift) in
+            # default parameter values (regression test for issue #223)
+            self.TestMultiLineLint(
+                """
+          class A {
+            A(int b, int c, int a = 1 << 1) {}
+          };""",
+                "",
+            )
             self.TestMultiLineLint(
                 """
           class Foo {

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1808,12 +1808,29 @@ class TestCpplint(CpplintTestBase):
           };""",
                 "",
             )
-            # No crash or warning for constructors with << (bitwise shift) in
-            # default parameter values (regression test for issue #223)
+            # No crash or warning for constructors with '<'-containing operators
+            # in default parameter values (regression test for issue #223).
+            # left shift <<
             self.TestMultiLineLint(
                 """
           class A {
             A(int b, int c, int a = 1 << 1) {}
+          };""",
+                "",
+            )
+            # compound left-shift-assign <<=
+            self.TestMultiLineLint(
+                """
+          class A {
+            A(int b, int c, int a = (x <<= 1)) {}
+          };""",
+                "",
+            )
+            # less-or-equal <=
+            self.TestMultiLineLint(
+                """
+          class A {
+            A(int b, int c, int a = b <= c ? 1 : 0) {}
           };""",
                 "",
             )


### PR DESCRIPTION
Used Claude to assist me to resolve [Issue#223](https://github.com/cpplint/cpplint/issues/223). The result looks good to me. Let me know if there are any room could be improved for these changes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed linting behavior that could miscount angle brackets and mis-handle constructor default arguments containing operator sequences (e.g., <<, <<=, <=), eliminating crashes and spurious warnings.

* **Tests**
  * Added multi-line tests to verify constructors with operator-containing default parameter expressions are processed correctly without warnings or failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->