### PR TITLE
fix: accept U/u integer-literal suffix before << in whitespace/operators

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -4533,7 +4533,7 @@ def CheckOperatorSpacing(filename, clean_lines, linenum, error):
     #
     # We also allow operators following an opening parenthesis, since
     # those tend to be macros that deal with operators.
-    match = re.search(r"(operator|[^\s(<])(?:U|UL|ULL|L|LL|u|ul|ull|l|ll)?<<([^\s,=<])", line)
+    match = re.search(r"(operator|[^\s(<])(?:U|UL|ULL|L|LL)?<<([^\s,=<])", line, flags=re.IGNORECASE)
     if (
         match
         and not (match.group(1).isdigit() and match.group(2).isdigit())

--- a/cpplint.py
+++ b/cpplint.py
@@ -4533,7 +4533,7 @@ def CheckOperatorSpacing(filename, clean_lines, linenum, error):
     #
     # We also allow operators following an opening parenthesis, since
     # those tend to be macros that deal with operators.
-    match = re.search(r"(operator|[^\s(<])(?:L|UL|LL|ULL|l|ul|ll|ull)?<<([^\s,=<])", line)
+    match = re.search(r"(operator|[^\s(<])(?:U|UL|ULL|L|LL|u|ul|ull|l|ll)?<<([^\s,=<])", line)
     if (
         match
         and not (match.group(1).isdigit() and match.group(2).isdigit())

--- a/cpplint.py
+++ b/cpplint.py
@@ -4533,7 +4533,9 @@ def CheckOperatorSpacing(filename, clean_lines, linenum, error):
     #
     # We also allow operators following an opening parenthesis, since
     # those tend to be macros that deal with operators.
-    match = re.search(r"(operator|[^\s(<])(?:U|UL|ULL|L|LL)?<<([^\s,=<])", line, flags=re.IGNORECASE)
+    match = re.search(
+        r"(operator|[^\s(<])(?:U|UL|ULL|L|LL)?<<([^\s,=<])", line, flags=re.IGNORECASE
+    )
     if (
         match
         and not (match.group(1).isdigit() and match.group(2).isdigit())

--- a/cpplint.py
+++ b/cpplint.py
@@ -4533,9 +4533,7 @@ def CheckOperatorSpacing(filename, clean_lines, linenum, error):
     #
     # We also allow operators following an opening parenthesis, since
     # those tend to be macros that deal with operators.
-    match = re.search(
-        r"(operator|[^\s(<])(?:U|UL|ULL|L|LL)?<<([^\s,=<])", line, flags=re.IGNORECASE
-    )
+    match = re.search(r"(operator|[^\s(<])(?i:U|UL|ULL|L|LL|LU|LLU)?<<([^\s,=<])", line)
     if (
         match
         and not (match.group(1).isdigit() and match.group(2).isdigit())

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3248,6 +3248,8 @@ class TestCpplint(CpplintTestBase):
         self.TestLint("a<<b", "Missing spaces around <<  [whitespace/operators] [3]")
         self.TestLint("10LL<<20", "")
         self.TestLint("10ULL<<20", "")
+        self.TestLint("10U<<20", "")
+        self.TestLint("10u<<20", "")
         self.TestLint("a>>b", "Missing spaces around >>  [whitespace/operators] [3]")
         self.TestLint("10>>b", "Missing spaces around >>  [whitespace/operators] [3]")
         self.TestLint("LOG(ERROR)<<*foo", "Missing spaces around <<  [whitespace/operators] [3]")


### PR DESCRIPTION
## Summary

The `whitespace/operators` check allows no-space shifts of suffixed integer literals (`10UL<<20`, `10LL<<20`), but the suffix alternation omitted the standalone `U`/`u` suffix, so `10U<<20` and `10u<<20` were wrongly reported as missing spaces around `<<`. This adds `U` and `u` to the alternation.

Added assertions for `10U<<20` and `10u<<20` next to the existing `10LL<<20`/`10ULL<<20` cases.

Closes #439.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator-spacing validation for the left-shift operator to better recognize numeric literal type prefixes, reducing incorrect “Missing spaces around <<” warnings.

* **Tests**
  * Added new single-line lint test cases for left-shift spacing with unsigned numeric literals using uppercase and lowercase `U` suffixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->