### PR TITLE
fix: handle lambdas in control conditions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 TBA
 ===
 
+* Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
+
 2.0.2 (2025-04-08)
 ===========
 

--- a/cpplint.py
+++ b/cpplint.py
@@ -5002,13 +5002,20 @@ def CheckBraces(filename, clean_lines, linenum, error):
     # No control clauses with braces should have its contents on the same line
     # Exclude } which will be covered by empty-block detect
     # Exclude ; which may be used by while in a do-while
-    if (
-        keyword := re.search(
-            r"\b(else if|if|while|for|switch)"  # These have parens
-            r"\s*\(.*\)\s*(?:\[\[(?:un)?likely\]\]\s*)?{\s*[^\s\\};]",
-            line,
+    keyword = re.search(
+        r"\b(else if|if|while|for|switch)\s*\(",
+        line,
+    )
+    if keyword:
+        (endline, endlinenum, endpos) = CloseExpression(
+            clean_lines, linenum, keyword.end() - 1
         )
-    ) or (
+        if endlinenum != linenum or not re.match(
+            r"\s*(?:\[\[(?:un)?likely\]\]\s*)?{\s*[^\s\\};]",
+            endline[endpos:],
+        ):
+            keyword = None
+    if keyword or (
         keyword := re.search(
             r"\b(else|do|try)"  # These don't have parens
             r"\s*(?:\[\[(?:un)?likely\]\]\s*)?{\s*[^\s\\}]",

--- a/cpplint.py
+++ b/cpplint.py
@@ -5007,9 +5007,7 @@ def CheckBraces(filename, clean_lines, linenum, error):
         line,
     )
     if keyword:
-        (endline, endlinenum, endpos) = CloseExpression(
-            clean_lines, linenum, keyword.end() - 1
-        )
+        (endline, endlinenum, endpos) = CloseExpression(clean_lines, linenum, keyword.end() - 1)
         if endlinenum != linenum or not re.match(
             r"\s*(?:\[\[(?:un)?likely\]\]\s*)?{\s*[^\s\\};]",
             endline[endpos:],

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -2957,6 +2957,14 @@ class TestCpplint(CpplintTestBase):
             "",
         )
 
+    def testInlineControlBodyWithLambda(self):
+        self.TestLint("if (all_of(v, [](auto b) { return b == 0; })) {", "")
+        self.TestLint(
+            "if (condition) { return true; }",
+            "Controlled statements inside brackets of if clause should be on a separate line"
+            "  [whitespace/newline] [5]",
+        )
+
     def testMismatchingSpacesInParens(self):
         self.TestLint("if (foo ) {", "Mismatching spaces inside () in if  [whitespace/parens] [5]")
         self.TestLint(


### PR DESCRIPTION
Fixes #410. 
 
The control-body check now uses CloseExpression to find the closing parenthesis of a control condition. 
This prevents lambda bodies inside conditions from being mistaken for inline control bodies. 
 
Checks: pytest with 226 passing tests, Pylint, and Mypy. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a false-positive whitespace/newline warning for control statements whose conditions contain inline lambda expressions.
  - Preserved warnings for control statements with inline brace-delimited bodies.

- **Tests**
  - Added coverage verifying correct handling of lambda-containing conditions and inline control bodies.

- **Documentation**
  - Updated the changelog with details of the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->