### PR TITLE
fix: handle multiline function templates in namespaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 TBA
 ===
 
+* Function template declarations with multiline template parameters no longer trigger ``whitespace/indent_namespace`` on their continuation lines.
+
 2.0.2 (2025-04-08)
 ===========
 

--- a/cpplint.py
+++ b/cpplint.py
@@ -4161,6 +4161,9 @@ def CheckForNamespaceIndentation(filename, nesting_state, clean_lines, line, err
         or (isinstance(nesting_state.previous_stack_top, _NamespaceInfo))
     )
 
+    if IsMultilineFunctionTemplateDeclaration(clean_lines, line):
+        return
+
     if ShouldCheckNamespaceIndentation(
         nesting_state, is_namespace_indent_item, clean_lines.elided, line
     ):
@@ -7381,6 +7384,36 @@ def IsBlockInNameSpace(nesting_state: NestingState, is_forward_declaration: bool
             )
         ):
             return True
+    return False
+
+
+def IsMultilineFunctionTemplateDeclaration(clean_lines, linenum):
+    """Checks whether a line continues a function template declaration."""
+    for start_line in range(linenum - 1, -1, -1):
+        line = clean_lines.elided[start_line]
+        if re.search(r"[;{}]", line):
+            return False
+
+        if template := re.search(r"\btemplate\s*<", line):
+            _, end_line, end_pos = CloseExpression(clean_lines, start_line, template.end() - 1)
+            if not start_line < linenum <= end_line or end_pos < 0:
+                return False
+
+            declaration = clean_lines.elided[end_line][end_pos:]
+            for next_line in range(end_line + 1, clean_lines.NumLines()):
+                declaration += " " + clean_lines.elided[next_line].strip()
+                if re.search(r"[;{}]", declaration):
+                    break
+
+            declaration = declaration.strip()
+            if not declaration or "{" in declaration.split(";", 1)[0]:
+                return False
+            if re.match(r"(?:class|enum|struct|using)\b", declaration):
+                return False
+
+            function = re.search(r"\b(?:operator\s*\S+|~?[A-Za-z_]\w*)\s*\(", declaration)
+            return function is not None and "=" not in declaration[: function.start()]
+
     return False
 
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -323,6 +323,38 @@ class TestCpplint(CpplintTestBase):
         results = self.GetNamespaceResults(lines)
         assert results == ""
 
+    def testNamespaceIndentationMultilineFunctionTemplateDeclaration(self):
+        lines = [
+            "namespace Test {",
+            "template <typename Type1,",
+            "          typename Type2>",
+            "void TestFunc(const Type1 &var1, Type2 &var2);",
+            "}  // namespace Test",
+        ]
+        assert self.GetNamespaceResults(lines) == ""
+
+        lines = [
+            "namespace Test {",
+            "template <typename T,",
+            "          typename Callback = void (*)(T)>",
+            "void Register(Callback callback);",
+            "}  // namespace Test",
+        ]
+        assert self.GetNamespaceResults(lines) == ""
+
+    def testNamespaceIndentationIndentedMultilineFunctionTemplateDeclaration(self):
+        lines = [
+            "namespace Test {",
+            "  template <typename Type1,",
+            "            typename Type2>",
+            "  void TestFunc(const Type1 &var1, Type2 &var2);",
+            "}  // namespace Test",
+        ]
+        assert self.GetNamespaceResults(lines) == [
+            "Do not indent within a namespace.  [whitespace/indent_namespace] [4]",
+            "Do not indent within a namespace.  [whitespace/indent_namespace] [4]",
+        ]
+
     def testNamespaceIndentationMemberInitializerList(self):
         lines = [
             "namespace Opossum {",

--- a/samples/boost-sample/simple.def
+++ b/samples/boost-sample/simple.def
@@ -2,7 +2,7 @@ include/boost/math/*
 1
 3
 Done processing include/boost/math/octonion.hpp
-Total errors found: 2900
+Total errors found: 2898
 
 include/boost/math/octonion.hpp:11:  #ifndef header guard has wrong style, please use: SAMPLES_BOOST_SAMPLE_INCLUDE_BOOST_MATH_OCTONION_HPP_  [build/header_guard] [5]
 include/boost/math/octonion.hpp:4250:  #endif line should be "#endif  // SAMPLES_BOOST_SAMPLE_INCLUDE_BOOST_MATH_OCTONION_HPP_"  [build/header_guard] [5]
@@ -290,8 +290,6 @@ include/boost/math/octonion.hpp:672:  { should almost always be at the end of th
 include/boost/math/octonion.hpp:673:  Do not indent within a namespace.  [whitespace/indent_namespace] [4]
 include/boost/math/octonion.hpp:673:  Line ends in whitespace.  Consider deleting these extra spaces.  [whitespace/end_of_line] [4]
 include/boost/math/octonion.hpp:674:  Do not indent within a namespace.  [whitespace/indent_namespace] [4]
-include/boost/math/octonion.hpp:675:  Do not indent within a namespace.  [whitespace/indent_namespace] [4]
-include/boost/math/octonion.hpp:676:  Do not indent within a namespace.  [whitespace/indent_namespace] [4]
 include/boost/math/octonion.hpp:677:  Do not indent within a namespace.  [whitespace/indent_namespace] [4]
 include/boost/math/octonion.hpp:678:  Do not indent within a namespace.  [whitespace/indent_namespace] [4]
 include/boost/math/octonion.hpp:679:  Do not indent within a namespace.  [whitespace/indent_namespace] [4]


### PR DESCRIPTION
Fixes #401.

## Root cause

The namespace-indentation regression made `is_namespace_indent_item` true whenever the current or previous nesting state was a namespace. That correctly catches indented functions, but also treats continuation lines inside a multiline template parameter list as namespace indentation.

## Changes

- Skip `whitespace/indent_namespace` only for lines inside a multiline template parameter list when the following statement is a function declaration.
- Preserve errors on genuinely indented template declarations and function declarations.
- Add positive and negative regression coverage.
- Update the existing Boost sample expectation for the same valid function-template pattern.

This intentionally does not change assignments, `using` aliases, enums, or the separate work discussed in #376.

## Validation

- `pytest -p no:cacheprovider`: 227 passed, 89.96% coverage
- `pylint --persistent=no cpplint.py`
- `mypy cpplint.py cpplint_unittest.py cpplint_clitest.py`
- `pre-commit` on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false-positive namespace indentation warnings for multiline function template declarations.
  * Correctly preserves warnings when continuation lines are genuinely over-indented.

* **Tests**
  * Added coverage for properly and improperly indented multiline function templates.

* **Documentation**
  * Updated the changelog with the linting fix.

* **Samples**
  * Updated the Boost sample output to reflect the corrected error count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->