### PR TITLE
fix: handle operators in constructor default arguments

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -3943,14 +3943,15 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
         else:
             constructor_args = explicit_constructor_match.group(2).split(",")
 
-        # collapse arguments so that commas in template parameter lists and function
-        # argument parameter lists don't split arguments in two
+        # Collapse commas inside template and function parameter lists.
         i = 0
         while i < len(constructor_args):
             constructor_arg = constructor_args[i]
-            while constructor_arg.count("<") > constructor_arg.count(">") or constructor_arg.count(
-                "("
-            ) > constructor_arg.count(")"):
+            # Ignore `<`-prefixed operators when balancing template brackets.
+            while i + 1 < len(constructor_args) and (
+                re.sub(r"<<=?|<=", "", constructor_arg).count("<") > constructor_arg.count(">")
+                or constructor_arg.count("(") > constructor_arg.count(")")
+            ):
                 constructor_arg += "," + constructor_args[i + 1]
                 del constructor_args[i + 1]
             constructor_args[i] = constructor_arg

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1810,6 +1810,37 @@ class TestCpplint(CpplintTestBase):
                 "Constructors callable with one argument should be marked explicit."
                 "  [runtime/explicit] [4]",
             )
+            # `<`-containing operators are not confused with template brackets.
+            self.TestMultiLineLint(
+                """
+          class A {
+            A(int a, int b, int c = 1 << 1);
+          };""",
+                "",
+            )
+            self.TestMultiLineLint(
+                """
+          class A {
+            A(int a = (value <<= 1), int b = 0, int c = 0);
+          };""",
+                "Constructors callable with one argument should be marked explicit."
+                "  [runtime/explicit] [4]",
+            )
+            self.TestMultiLineLint(
+                """
+          class A {
+            A(int a, bool b = 1 <= 1, int c = 0);
+          };""",
+                "Constructors callable with one argument should be marked explicit."
+                "  [runtime/explicit] [4]",
+            )
+            self.TestMultiLineLint(
+                """
+          class A {
+            A(int a, int b, bool c = 1 < 2);
+          };""",
+                "",
+            )
             # explicit no-argument constructors are just fine
             self.TestMultiLineLint(
                 """


### PR DESCRIPTION
Fixes #223.

Supersedes #426 and addresses the review feedback left there.

## What changed

- Treat `<<`, `<<=`, and `<=` as operators rather than template openers when collapsing constructor arguments.
- Stop collapsing when no following comma-separated argument remains.
- Add regression cases for `<`, `<=`, `<<`, and `<<=` in different parameter positions.

## Root cause

`CheckForNonStandardConstructs` counted every `<` when balancing template arguments. An operator in a constructor default value therefore looked like an unmatched template opener, and the comma-collapsing loop read past the end of `constructor_args`.

## Review follow-up

- Keep the regex replacement inline instead of adding a global compiled regex.
- Keep the comments terse and the operator explanation beside the expression.
- Rotate parameter positions in the tests.

## Validation

- `pytest`: 231 passed, 96.46% coverage
- `ruff check` and `ruff format --check`
- `pylint cpplint.py`
- `mypy cpplint.py cpplint_clitest.py cpplint_unittest.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of single-argument constructors when default arguments contain bitshift or comparison operators.
  * Reduced false positives caused by operators being mistaken for template syntax.

* **Tests**
  * Added coverage for constructor arguments using bitshift and relational operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->