### PR TITLE
fix(runtime/explicit): skip deleted constructors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ TBA
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
 * We now error on relative include paths (``./``, ``../``). (#432)
    * This makes ``#include "./foo.h"`` produce two separate errors: that foo.cpp should include foo.h and that relative paths are not allowed.
+* Deleted single-argument constructors no longer trigger ``runtime/explicit``. (#386)
 
 2.0.2 (2025-04-08)
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ TBA
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
 * We now error on relative include paths (``./``, ``../``). (#432)
    * This makes ``#include "./foo.h"`` produce two separate errors: that foo.cpp should include foo.h and that relative paths are not allowed.
-* Deleted single-argument constructors no longer trigger ``runtime/explicit``. (#386)
+* Deleted single-argument constructors, including C++20 requires-expressions, no longer trigger ``runtime/explicit``. (#386)
 
 2.0.2 (2025-04-08)
 ===========

--- a/cpplint.py
+++ b/cpplint.py
@@ -3973,8 +3973,8 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
             clean_lines, linenum, explicit_constructor_match.end()
         )
         is_deleted = bool(
-            re.match(
-                r"\s*(?:noexcept(?:\s*\(.*\))?\s*)?=\s*delete\s*;",
+            re.search(
+                r"=\s*delete\s*(?:\(.*\))?\s*;\s*$",
                 constructor_suffix,
                 re.DOTALL,
             )

--- a/cpplint.py
+++ b/cpplint.py
@@ -3786,6 +3786,43 @@ class NestingState:
         return None
 
 
+def _GetConstructorSuffix(clean_lines, linenum, match_end):
+    """Returns the constructor declaration suffix up to its top-level terminator."""
+    constructor_suffix = []
+    paren_depth = 0
+    bracket_depth = 0
+    brace_depth = 0
+    suffix_line = clean_lines.elided[linenum][match_end:]
+    next_line = linenum + 1
+
+    while True:
+        for char in suffix_line:
+            if char == ";" and not paren_depth and not bracket_depth and not brace_depth:
+                constructor_suffix.append(char)
+                return "".join(constructor_suffix)
+            if char == "{" and not paren_depth and not bracket_depth and not brace_depth:
+                return "".join(constructor_suffix)
+
+            constructor_suffix.append(char)
+            if char == "(":
+                paren_depth += 1
+            elif char == ")":
+                paren_depth -= 1
+            elif char == "[":
+                bracket_depth += 1
+            elif char == "]":
+                bracket_depth -= 1
+            elif char == "{":
+                brace_depth += 1
+            elif char == "}":
+                brace_depth -= 1
+
+        if next_line >= clean_lines.NumLines():
+            return "".join(constructor_suffix)
+        suffix_line = "\n" + clean_lines.elided[next_line]
+        next_line += 1
+
+
 def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state, error):
     r"""Logs an error if we see certain non-ANSI constructs ignored by gcc-2.
 
@@ -3932,19 +3969,14 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
 
     if explicit_constructor_match:
         is_marked_explicit = explicit_constructor_match.group(1)
-        constructor_suffix = line[explicit_constructor_match.end() :]
-        next_line = linenum + 1
-        while (
-            ";" not in constructor_suffix
-            and "{" not in constructor_suffix
-            and next_line < clean_lines.NumLines()
-        ):
-            constructor_suffix += clean_lines.lines[next_line]
-            next_line += 1
+        constructor_suffix = _GetConstructorSuffix(
+            clean_lines, linenum, explicit_constructor_match.end()
+        )
         is_deleted = bool(
             re.match(
-                r"\s*(?:noexcept(?:\s*\([^;{}]*\))?\s*)?=\s*delete\s*;",
+                r"\s*(?:noexcept(?:\s*\(.*\))?\s*)?=\s*delete\s*;",
                 constructor_suffix,
+                re.DOTALL,
             )
         )
 

--- a/cpplint.py
+++ b/cpplint.py
@@ -3926,12 +3926,13 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
     explicit_constructor_match = re.match(
         r"\s+(?:(?:inline|constexpr)\s+)*(explicit\s+)?"
         rf"(?:(?:inline|constexpr)\s+)*{re.escape(base_classname)}\s*"
-        r"\(((?:[^()]|\([^()]*\))*)\)",
+        r"\(((?:[^()]|\([^()]*\))*)\)\s*(=\s*delete\s*;)?",
         line,
     )
 
     if explicit_constructor_match:
         is_marked_explicit = explicit_constructor_match.group(1)
+        is_deleted = bool(explicit_constructor_match.group(3))
 
         if not explicit_constructor_match.group(2):
             constructor_args = []
@@ -3990,6 +3991,7 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
 
         if (
             not is_marked_explicit
+            and not is_deleted
             and onearg_constructor
             and not initializer_list_constructor
             and not copy_constructor

--- a/cpplint.py
+++ b/cpplint.py
@@ -3792,16 +3792,26 @@ def _GetConstructorSuffix(clean_lines, linenum, match_end):
     paren_depth = 0
     bracket_depth = 0
     brace_depth = 0
+    in_requires_clause = False
+    requires_expression = False
     suffix_line = clean_lines.elided[linenum][match_end:]
     next_line = linenum + 1
 
     while True:
-        for char in suffix_line:
-            if char == ";" and not paren_depth and not bracket_depth and not brace_depth:
-                constructor_suffix.append(char)
-                return "".join(constructor_suffix)
-            if char == "{" and not paren_depth and not bracket_depth and not brace_depth:
-                return "".join(constructor_suffix)
+        for char in re.findall(r"\w+|[^\w]", suffix_line):
+            if not paren_depth and not bracket_depth and not brace_depth:
+                if char == ";":
+                    constructor_suffix.append(char)
+                    return "".join(constructor_suffix)
+                if char == "{" and not requires_expression:
+                    return "".join(constructor_suffix)
+                if char == "requires":
+                    # The first keyword starts the clause; subsequent ones
+                    # introduce expressions whose braces belong to the suffix.
+                    requires_expression = in_requires_clause
+                    in_requires_clause = True
+                elif not char.isspace() and char != "(":
+                    requires_expression = False
 
             constructor_suffix.append(char)
             if char == "(":

--- a/cpplint.py
+++ b/cpplint.py
@@ -3926,13 +3926,27 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum, nesting_state,
     explicit_constructor_match = re.match(
         r"\s+(?:(?:inline|constexpr)\s+)*(explicit\s+)?"
         rf"(?:(?:inline|constexpr)\s+)*{re.escape(base_classname)}\s*"
-        r"\(((?:[^()]|\([^()]*\))*)\)\s*(=\s*delete\s*;)?",
+        r"\(((?:[^()]|\([^()]*\))*)\)",
         line,
     )
 
     if explicit_constructor_match:
         is_marked_explicit = explicit_constructor_match.group(1)
-        is_deleted = bool(explicit_constructor_match.group(3))
+        constructor_suffix = line[explicit_constructor_match.end() :]
+        next_line = linenum + 1
+        while (
+            ";" not in constructor_suffix
+            and "{" not in constructor_suffix
+            and next_line < clean_lines.NumLines()
+        ):
+            constructor_suffix += clean_lines.lines[next_line]
+            next_line += 1
+        is_deleted = bool(
+            re.match(
+                r"\s*(?:noexcept(?:\s*\([^;{}]*\))?\s*)?=\s*delete\s*;",
+                constructor_suffix,
+            )
+        )
 
         if not explicit_constructor_match.group(2):
             constructor_args = []

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1666,6 +1666,28 @@ class TestCpplint(CpplintTestBase):
             self.TestMultiLineLint(
                 """
           class Foo {
+            template <class T>
+            Foo(T value) requires Integral<T> = delete;
+          };""",
+                "",
+            )
+            self.TestMultiLineLint(
+                """
+          class Foo {
+            Foo(int f) throw() = delete;
+          };""",
+                "",
+            )
+            self.TestMultiLineLint(
+                """
+          class Foo {
+            Foo(int f) = delete("use Bar instead");
+          };""",
+                "",
+            )
+            self.TestMultiLineLint(
+                """
+          class Foo {
             Foo(int f)
                 = delete;
           };""",

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1648,6 +1648,13 @@ class TestCpplint(CpplintTestBase):
                     expected,
                 )
 
+    def testNonDeletedConstructorSuffixes(self):
+        for suffix in ("noexcept", "noexcept(noexcept(T{}))", "throw()"):
+            self.TestMultiLineLint(
+                f"class Foo {{\n  Foo(int value) {suffix};\n}};",
+                "Single-parameter constructors should be marked explicit.  [runtime/explicit] [4]",
+            )
+
     def testConstructorSuffixStopsAtBody(self):
         for suffix in (
             "requires (sizeof(T) > 0)",

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1659,6 +1659,13 @@ class TestCpplint(CpplintTestBase):
             self.TestMultiLineLint(
                 """
           class Foo {
+            Foo(int f) noexcept(noexcept(T{})) = delete;
+          };""",
+                "",
+            )
+            self.TestMultiLineLint(
+                """
+          class Foo {
             Foo(int f)
                 = delete;
           };""",

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1674,6 +1674,14 @@ class TestCpplint(CpplintTestBase):
             self.TestMultiLineLint(
                 """
           class Foo {
+            template <class T>
+            Foo(T value) requires Integral<T>;
+          };""",
+                "Single-parameter constructors should be marked explicit.  [runtime/explicit] [4]",
+            )
+            self.TestMultiLineLint(
+                """
+          class Foo {
             Foo(int f) throw() = delete;
           };""",
                 "",

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1632,8 +1632,10 @@ class TestCpplint(CpplintTestBase):
             "requires requires(T value) { value + value; }",
             "requires requires\n                (T value)\n                { value + value; }",
             "requires requires(T value) { { value + value }; }",
-            "requires requires { typename T::type; }\n"
-            "      && requires(T value) { value + value; }",
+            (
+                "requires requires { typename T::type; }\n"
+                "      && requires(T value) { value + value; }"
+            ),
         )
         for suffix in suffixes:
             for ending, expected in (

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1639,6 +1639,14 @@ class TestCpplint(CpplintTestBase):
           };""",
                 "Single-parameter constructors should be marked explicit.  [runtime/explicit] [4]",
             )
+            # Deleted constructors cannot be called implicitly.
+            self.TestMultiLineLint(
+                """
+          class Foo {
+            Foo(int f) = delete;
+          };""",
+                "",
+            )
             # missing explicit is bad, even with whitespace
             self.TestMultiLineLint(
                 """

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1647,6 +1647,23 @@ class TestCpplint(CpplintTestBase):
           };""",
                 "",
             )
+            # Deleted constructors may include a noexcept suffix or split the
+            # deleted marker across lines.
+            self.TestMultiLineLint(
+                """
+          class Foo {
+            Foo(int f) noexcept = delete;
+          };""",
+                "",
+            )
+            self.TestMultiLineLint(
+                """
+          class Foo {
+            Foo(int f)
+                = delete;
+          };""",
+                "",
+            )
             # missing explicit is bad, even with whitespace
             self.TestMultiLineLint(
                 """

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1625,6 +1625,40 @@ class TestCpplint(CpplintTestBase):
             # One per line.
             assert error_collector.ResultList().count(multiline_string_error_message) == 2
 
+    def testConstrainedDeletedConstructors(self):
+        warning = "Single-parameter constructors should be marked explicit.  [runtime/explicit] [4]"
+        suffixes = (
+            "requires requires { typename T::type; }",
+            "requires requires(T value) { value + value; }",
+            "requires requires\n                (T value)\n                { value + value; }",
+            "requires requires(T value) { { value + value }; }",
+            "requires requires { typename T::type; }\n"
+            "      && requires(T value) { value + value; }",
+        )
+        for suffix in suffixes:
+            for ending, expected in (
+                (" = delete;", ""),
+                (";", warning),
+                (" {}", warning),
+            ):
+                self.TestMultiLineLint(
+                    f"class Foo {{\n  template <class T>\n  Foo(T value) {suffix}{ending}\n}};",
+                    expected,
+                )
+
+    def testConstructorSuffixStopsAtBody(self):
+        for suffix in (
+            "requires (sizeof(T) > 0)",
+            "requires Integral<T>",
+            "requires requires { typename T::type; }",
+            "requires requires(T value) { value + value; }",
+        ):
+            declaration = f"Foo(T value) {suffix} {{}}\nFoo(int) = delete;"
+            clean_lines = cpplint.CleansedLines(declaration.splitlines())
+            assert cpplint._GetConstructorSuffix(clean_lines, 0, len("Foo(T value)")) == (
+                f" {suffix} "
+            )
+
     # Test non-explicit single-argument constructors
     def testExplicitSingleArgumentConstructors(self):
         old_verbose_level = cpplint._cpplint_state.verbose_level


### PR DESCRIPTION
## Purpose

Fixes #386. Deleted single-argument constructors trigger `runtime/explicit` even though they cannot be called implicitly.

## Rationale

Inspect the constructor declaration suffix for a trailing `= delete;`, including multiline declarations, nested `noexcept` expressions, and C++20 constraints. Distinguish the braces of a requires-expression from the actual constructor body. Ordinary single-argument constructors retain the existing warning, and suffix scanning stops before the next declaration.

## How did you test?

- Added deleted and non-deleted cases for requires-expressions with and without parameters, multiline requirements, compound requirements, and conjunctions.
- Added body-boundary checks for both ordinary constraints and requires-expressions followed by another deleted constructor.
- Full pytest suite: 233 passed; coverage 96.40% (95% required).
- `python -m pylint cpplint.py` passes.
- Configured pre-commit hooks for the three changed files pass.
- Validated the C++20 declarations with `clang++ -std=c++20 -pedantic-errors -fsyntax-only`.
- `git diff --check` passes.

## How to Verify

Run `python -m pytest --no-cov cpplint_unittest.py -k 'ConstrainedDeletedConstructors or ConstructorSuffixStopsAtBody or ExplicitSingleArgumentConstructors'` and confirm the deleted declarations are accepted while ordinary constructors still require `explicit`.
