### PR TITLE
fix: handle templated lambdas in semicolon check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ TBA
 ===
 
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
+* Fixed a readability/braces false positive for C++20 templated lambdas. (#385)
 
 2.0.2 (2025-04-08)
 ===========

--- a/cpplint.py
+++ b/cpplint.py
@@ -5078,6 +5078,50 @@ def CheckBraces(filename, clean_lines, linenum, error):
                         )
 
 
+def MatchLambdaCapture(clean_lines, linenum, line_prefix):
+    """Matches a lambda capture before an optional template parameter list."""
+    capture = re.match(r"^(.*\])\s*$", line_prefix)
+    if capture or not re.search(r">\s*$", line_prefix):
+        return capture
+
+    template_end = line_prefix.rfind(">")
+    template_start = ReverseCloseExpression(clean_lines, linenum, template_end)
+    if template_start[2] < 0:
+        return None
+
+    capture_prefix = template_start[0][0 : template_start[2]]
+    if not capture_prefix.strip() and template_start[1] > 0:
+        capture_prefix = GetPreviousNonBlankLine(clean_lines, template_start[1])[0]
+    return re.match(r"^(.*\])\s*$", capture_prefix)
+
+
+def MatchLambdaRequiresClause(clean_lines, linenum):
+    """Matches the lambda capture preceding a multiline requires-clause."""
+    while linenum >= 0:
+        line = clean_lines.elided[linenum]
+        if requires := re.search(r"\brequires\b", line):
+            capture = MatchLambdaCapture(
+                clean_lines,
+                linenum,
+                line[0 : requires.start()],
+            )
+            if capture:
+                return capture
+            template_line, template_linenum = GetPreviousNonBlankLine(
+                clean_lines,
+                linenum,
+            )
+            return MatchLambdaCapture(
+                clean_lines,
+                template_linenum,
+                template_line,
+            )
+        if re.search(r"[;{}]\s*$", line):
+            return None
+        _, linenum = GetPreviousNonBlankLine(clean_lines, linenum)
+    return None
+
+
 def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
     """Looks for redundant trailing semicolon.
 
@@ -5168,7 +5212,11 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
         if opening_parenthesis[2] > -1:
             line_prefix = opening_parenthesis[0][0 : opening_parenthesis[2]]
             macro = re.search(r"\b([A-Z_][A-Z0-9_]*)\s*$", line_prefix)
-            func = re.match(r"^(.*\])\s*$", line_prefix)
+            func = MatchLambdaCapture(
+                clean_lines,
+                opening_parenthesis[1],
+                line_prefix,
+            )
             if (
                 (
                     macro
@@ -5192,13 +5240,24 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
                 or re.search(r"\s+=\s*$", line_prefix)
             ):
                 match = None
-        if (
-            match
-            and opening_parenthesis[1] > 1
-            and re.search(r"\]\s*$", clean_lines.elided[opening_parenthesis[1] - 1])
-        ):
-            # Multi-line lambda-expression
-            match = None
+        if match and opening_parenthesis[1] > 0:
+            previous_line, previous_linenum = GetPreviousNonBlankLine(
+                clean_lines,
+                opening_parenthesis[1],
+            )
+            func = MatchLambdaCapture(
+                clean_lines,
+                previous_linenum,
+                previous_line,
+            )
+            if not func:
+                func = MatchLambdaRequiresClause(
+                    clean_lines,
+                    previous_linenum,
+                )
+            if func and not re.search(r"\boperator\s*\[\s*\]", func.group(1)):
+                # Multi-line lambda-expression
+                match = None
 
     else:
         # Try matching cases 2-3.

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3166,8 +3166,49 @@ class TestCpplint(CpplintTestBase):
         self.TestLint("auto x = []() {};", "")
         self.TestLint("return []() {};", "")
         self.TestMultiLineLint("auto x = []() {\n};\n", "")
+        self.TestMultiLineLint(
+            "int main() {\n  auto identity = []<typename T>(T&& t) {\n    return t;\n  };\n}\n",
+            "",
+        )
+        self.TestMultiLineLint(
+            "auto identity = []<\n    typename T\n>(T&& t) {\n  return t;\n};\n",
+            "",
+        )
+        self.TestMultiLineLint(
+            "auto identity = []<typename T>\n(T&& t) {\n  return t;\n};\n",
+            "",
+        )
+        self.TestMultiLineLint(
+            "auto identity = []\n<typename T>\n(T&& t) {\n  return t;\n};\n",
+            "",
+        )
+        self.TestMultiLineLint(
+            "auto identity = []<typename T>\n"
+            "    requires std::integral<T>\n"
+            "(T&& t) {\n"
+            "  return t;\n"
+            "};\n",
+            "",
+        )
+        self.TestMultiLineLint(
+            "auto identity = []<typename T>\n"
+            "    requires std::integral<T> &&\n"
+            "             std::copyable<T>\n"
+            "(T&& t) {\n"
+            "  return t;\n"
+            "};\n",
+            "",
+        )
         self.TestLint(
             "int operator[](int x) {};", "You don't need a ; after a }  [readability/braces] [4]"
+        )
+        self.TestMultiLineLint(
+            "int operator[]\n(int x) {};",
+            "You don't need a ; after a }  [readability/braces] [4]",
+        )
+        self.TestMultiLineLint(
+            "template <typename T>\n  requires C<T>\nvoid Function(T value) {};",
+            "You don't need a ; after a }  [readability/braces] [4]",
         )
 
         self.TestMultiLineLint("auto x = [&a,\nb]() {};", "")


### PR DESCRIPTION
  Fixes #385.

  The trailing-semicolon check now recognizes C++20 templated lambdas,
  including multiline template parameter lists and requires-clauses.

  The existing warnings for operator[] and ordinary constrained function
  definitions remain unchanged.

  Tests:
  - pytest — 231 passed, 96.43% coverage
  - pylint cpplint.py
  - pre-commit run --all-files
  - C++20 examples verified with g++ -std=c++20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false-positive readability warnings for C++20 templated lambdas, including multiline `requires` clauses.
  * Improved handling of multiline lambda syntax to avoid incorrectly flagging valid code for redundant trailing semicolons.

* **Tests**
  * Added coverage for templated lambdas with multiline parameters, bodies, and constraints.

* **Documentation**
  * Updated the changelog with details of the readability warning fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->