### PR TITLE
Fix/include path aliases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ TBA
 ===
 
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
+* Disallowed current- and parent-directory aliases in include paths. (#432)
 
 2.0.2 (2025-04-08)
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ TBA
 ===
 
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
-* Disallowed current- and parent-directory aliases in include paths. (#432)
+* We now error on relative include paths (``./``, ``../``). (#432)
+   * This makes ``#include "./foo.h"`` produce two separate errors: that foo.cpp should include foo.h and that relative paths are not allowed.
 
 2.0.2 (2025-04-08)
 ===========

--- a/cpplint.py
+++ b/cpplint.py
@@ -2706,11 +2706,6 @@ def CheckForHeaderGuard(filename, clean_lines, error, cppvar):
     )
 
 
-def _IncludePathUsesDirectoryAlias(include):
-    """Returns whether an include path contains a . or .. component."""
-    return any(component in (".", "..") for component in include.split("/"))
-
-
 def CheckHeaderFileIncluded(filename, include_state, error):
     """Logs an error if a source file does not include its header."""
 
@@ -2726,20 +2721,15 @@ def CheckHeaderFileIncluded(filename, include_state, error):
         if not os.path.exists(headerfile):
             continue
         headername = FileInfo(headerfile).RepositoryName()
-        include_uses_unix_dir_aliases = False
         for section_list in include_state.include_list:
             for f in section_list:
                 include_text = f[0]
-                if _IncludePathUsesDirectoryAlias(include_text):
-                    include_uses_unix_dir_aliases = True
                 if headername in include_text or include_text in headername:
                     return
                 if not first_include:
                     first_include = f[1]
 
         message = f"{fileinfo.RepositoryName()} should include its header file {headername}"
-        if include_uses_unix_dir_aliases:
-            message += ". Relative paths like . and .. are not allowed."
 
     if message:
         error(filename, first_include, "build/include", 5, message)
@@ -5831,6 +5821,11 @@ def _ClassifyInclude(fileinfo, include, used_angle_brackets, include_order="defa
     return _OTHER_HEADER
 
 
+def IncludePathUsesDirectoryAlias(include):
+    """Returns whether an include path contains a . or .. component."""
+    return include.startswith(("../", "./")) or "/../" in include or "/./" in include
+
+
 def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
     """Check rules that are applicable to #include lines.
 
@@ -5876,13 +5871,13 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
     if match:
         include = match.group(2)
         used_angle_brackets = match.group(1) == "<"
-        if _IncludePathUsesDirectoryAlias(include):
+        if IncludePathUsesDirectoryAlias(include):
             error(
                 filename,
                 linenum,
                 "build/include",
                 4,
-                "Include path contains a directory alias",
+                "Relative paths like . and .. are not allowed.",
             )
         duplicate_line = include_state.FindHeader(include)
         if duplicate_line >= 0:

--- a/cpplint.py
+++ b/cpplint.py
@@ -5871,6 +5871,14 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
     if match:
         include = match.group(2)
         used_angle_brackets = match.group(1) == "<"
+        if re.search(r"(?:^|/)\.{1,2}(?:/|$)", include):
+            error(
+                filename,
+                linenum,
+                "build/include",
+                4,
+                "Include path contains a directory alias",
+            )
         duplicate_line = include_state.FindHeader(include)
         if duplicate_line >= 0:
             error(

--- a/cpplint.py
+++ b/cpplint.py
@@ -2706,6 +2706,11 @@ def CheckForHeaderGuard(filename, clean_lines, error, cppvar):
     )
 
 
+def _IncludePathUsesDirectoryAlias(include):
+    """Returns whether an include path contains a . or .. component."""
+    return any(component in (".", "..") for component in include.split("/"))
+
+
 def CheckHeaderFileIncluded(filename, include_state, error):
     """Logs an error if a source file does not include its header."""
 
@@ -2725,7 +2730,7 @@ def CheckHeaderFileIncluded(filename, include_state, error):
         for section_list in include_state.include_list:
             for f in section_list:
                 include_text = f[0]
-                if "./" in include_text:
+                if _IncludePathUsesDirectoryAlias(include_text):
                     include_uses_unix_dir_aliases = True
                 if headername in include_text or include_text in headername:
                     return
@@ -5871,7 +5876,7 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
     if match:
         include = match.group(2)
         used_angle_brackets = match.group(1) == "<"
-        if re.search(r"(?:^|/)\.{1,2}(?:/|$)", include):
+        if _IncludePathUsesDirectoryAlias(include):
             error(
                 filename,
                 linenum,

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -5832,6 +5832,15 @@ func2();""",
         )
         self.TestLint('#include "baz.aa"', "")
         self.TestLint('#include "dir/foo.h"', "")
+        self.TestLint(
+            '#include "../foo/bar.h"',
+            "Include path contains a directory alias  [build/include] [4]",
+        )
+        self.TestLint(
+            '#include "private/./test.h"',
+            "Include path contains a directory alias  [build/include] [4]",
+        )
+        self.TestLint('#include "dir/foo..h"', "")
         self.TestLint('#include "Python.h"', "")
         self.TestLint('#include "lua.h"', "")
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -5704,21 +5704,14 @@ func2();""",
             )
             assert error_collector.Results().count(expected) == 0
 
-            # Unix directory aliases are not allowed, and should trigger the
-            # "include itse header file" error
+            # Unix directory aliases should be reported separately from a
+            # missing related-header error.
             error_collector = ErrorCollector(self.assertTrue)
             cpplint.ProcessFileData(
                 "test/foo.cc", "cc", [r'#include "./test/foo.h"', ""], error_collector
             )
-            fmt = "{dir}/{fn}.cc should include its header file {dir}/{fn}.h{unix_text}"
-            expected = (
-                fmt.format(
-                    fn="foo",
-                    dir=test_directory,
-                    unix_text=". Relative paths like . and .. are not allowed.",
-                )
-                + "  [build/include] [5]"
-            )
+            alias_error = "Relative paths like . and .. are not allowed.  [build/include] [4]"
+            assert error_collector.Results().count(alias_error) == 1
             assert error_collector.Results().count(expected) == 1
 
             # A directory name ending in dots is not a Unix directory alias.
@@ -5847,11 +5840,11 @@ func2();""",
         self.TestLint('#include "dir/foo.h"', "")
         self.TestLint(
             '#include "../foo/bar.h"',
-            "Include path contains a directory alias  [build/include] [4]",
+            "Relative paths like . and .. are not allowed.  [build/include] [4]",
         )
         self.TestLint(
             '#include "private/./test.h"',
-            "Include path contains a directory alias  [build/include] [4]",
+            "Relative paths like . and .. are not allowed.  [build/include] [4]",
         )
         self.TestLint('#include "dir/foo..h"', "")
         self.TestLint('#include "Python.h"', "")

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -5721,6 +5721,19 @@ func2();""",
             )
             assert error_collector.Results().count(expected) == 1
 
+            # A directory name ending in dots is not a Unix directory alias.
+            error_collector = ErrorCollector(self.assertTrue)
+            cpplint.ProcessFileData(
+                "test/foo.cc",
+                "cc",
+                [r'#include "test/foo../bar.h"', ""],
+                error_collector,
+            )
+            assert not any(
+                "Relative paths like . and .. are not allowed." in error
+                for error in error_collector.Results()
+            )
+
             # This should continue to work
             error_collector = ErrorCollector(self.assertTrue)
             cpplint.ProcessFileData(

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -5695,14 +5695,14 @@ func2();""",
             if platform.system() == "Windows":
                 test_directory = test_directory.replace("\\", "/")
             fmt = "{dir}/{fn}.cc should include its header file {dir}/{fn}.h  [build/include] [5]"
-            expected = fmt.format(fn="foo", dir=test_directory)
-            assert error_collector.Results().count(expected) == 1
+            foo_header_error = fmt.format(fn="foo", dir=test_directory)
+            assert error_collector.Results().count(foo_header_error) == 1
 
             error_collector = ErrorCollector(self.assertTrue)
             cpplint.ProcessFileData(
                 "test/foo.cc", "cc", [r'#include "test/foo.h"', ""], error_collector
             )
-            assert error_collector.Results().count(expected) == 0
+            assert error_collector.Results().count(foo_header_error) == 0
 
             # Unix directory aliases should be reported separately from a
             # missing related-header error.
@@ -5710,9 +5710,11 @@ func2();""",
             cpplint.ProcessFileData(
                 "test/foo.cc", "cc", [r'#include "./test/foo.h"', ""], error_collector
             )
-            alias_error = "Relative paths like . and .. are not allowed.  [build/include] [4]"
-            assert error_collector.Results().count(alias_error) == 1
-            assert error_collector.Results().count(expected) == 1
+            relative_path_error = (
+                "Relative paths like . and .. are not allowed.  [build/include] [4]"
+            )
+            assert error_collector.Results().count(relative_path_error) == 1
+            assert error_collector.Results().count(foo_header_error) == 1
 
             # A directory name ending in dots is not a Unix directory alias.
             error_collector = ErrorCollector(self.assertTrue)
@@ -5733,20 +5735,20 @@ func2();""",
                 "test/Bar.cc", "cc", [r'#include "test/Bar.h"', ""], error_collector
             )
             fmt = "{dir}/{fn}.cc should include its header file {dir}/{fn}.h  [build/include] [5]"
-            expected = fmt.format(fn="Bar", dir=test_directory)
-            assert error_collector.Results().count(expected) == 0
+            bar_header_error = fmt.format(fn="Bar", dir=test_directory)
+            assert error_collector.Results().count(bar_header_error) == 0
 
             # Since Bar.cc & Bar.h look 3rd party-ish, it should be ok without the include dir
             error_collector = ErrorCollector(self.assertTrue)
             cpplint.ProcessFileData("test/Bar.cc", "cc", [r'#include "Bar.h"', ""], error_collector)
-            assert error_collector.Results().count(expected) == 0
+            assert error_collector.Results().count(bar_header_error) == 0
 
             # Test edge case in which multiple files have the same base name
             open(os.path.join(test_directory, "foo.hpp"), "a").close()
             cpplint.ProcessFileData(
                 "test/foo.cc", "cc", [r'#include "foo.hpp"', ""], error_collector
             )
-            assert error_collector.Results().count(expected) == 0
+            assert error_collector.Results().count(bar_header_error) == 0
 
         finally:
             # Restore previous CWD.

--- a/samples/vlc-sample/simple.def
+++ b/samples/vlc-sample/simple.def
@@ -4,8 +4,9 @@ src/*
 Done processing src/libvlc.c
 Done processing src/libvlc.h
 Done processing src/missing.c
-Total errors found: 599
+Total errors found: 600
 
+src/libvlc.c:40:  Include path contains a directory alias  [build/include] [4]
 src/libvlc.c:41:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:47:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:48:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]

--- a/samples/vlc-sample/simple.def
+++ b/samples/vlc-sample/simple.def
@@ -6,7 +6,7 @@ Done processing src/libvlc.h
 Done processing src/missing.c
 Total errors found: 600
 
-src/libvlc.c:40:  Include path contains a directory alias  [build/include] [4]
+src/libvlc.c:40:  Relative paths like . and .. are not allowed.  [build/include] [4]
 src/libvlc.c:41:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:47:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:48:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]


### PR DESCRIPTION
 Fixes #432.

  The include-path check now rejects `./` and `../` aliases at the beginning
  of or within an include path.

  Alias violations use the existing “Relative paths like . and .. are not
  allowed.” wording and are reported separately from related-header errors.
  Valid path components that merely end in dots, such as `foo../bar.h`,
  remain accepted.

  The VLC sample expectation has also been updated because it contains an
  existing `../` include.

  Tests:
  - pytest — 231 passed, 96.46% coverage
  - pylint cpplint.py
  - pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for include paths containing relative directory aliases such as `./` and `../`.
  * Reports clearer, dedicated warnings when these path patterns are used.
  * Avoids incorrectly flagging filenames that merely contain consecutive dots.
  * Separately reports relative-path violations and missing-header issues for clearer troubleshooting.

* **Documentation**
  * Updated the changelog and sample output to reflect the revised warning message and diagnostic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->