### PR TITLE
fix(braces): exempt C++20 templated lambdas from trailing-semicolon check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ TBA
 ===
 
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
+* Fixed a false positive where C++20 templated lambdas (``[]<T>(...)``) triggered the redundant trailing semicolon warning. (#385)
 
 2.0.2 (2025-04-08)
 ===========

--- a/cpplint.py
+++ b/cpplint.py
@@ -5186,6 +5186,7 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
                     )
                 )
                 or (func and not re.search(r"\boperator\s*\[\s*\]", func.group(1)))
+                or re.search(r"\]\s*<.*>\s*$", line_prefix)
                 or re.search(r"\b(?:struct|union)\s+alignas\s*$", line_prefix)
                 or re.search(r"\bdecltype$", line_prefix)
                 or re.search(r"\brequires.*$", line_prefix)

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3191,9 +3191,7 @@ class TestCpplint(CpplintTestBase):
         self.TestLint("auto x = []<typename T>(T) {};", "")
         self.TestLint("auto x = [&]<typename T, int N>(T (&a)[N]) {};", "")
         self.TestMultiLineLint(
-            "auto x = []<typename T>(T t) {\n"
-            "  return t;\n"
-            "};\n",
+            "auto x = []<typename T>(T t) {\n  return t;\n};\n",
             "",
         )
         # A templated *function* (not a lambda) with a redundant trailing

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3186,6 +3186,23 @@ class TestCpplint(CpplintTestBase):
         # Avoid false positives with operator[]
         self.TestLint("table_to_children[&*table].push_back(dependent);", "")
 
+        # C++20 templated lambdas: []<T>(...) must not trigger the redundant
+        # trailing semicolon check. Regression test for #385.
+        self.TestLint("auto x = []<typename T>(T) {};", "")
+        self.TestLint("auto x = [&]<typename T, int N>(T (&a)[N]) {};", "")
+        self.TestMultiLineLint(
+            "auto x = []<typename T>(T t) {\n"
+            "  return t;\n"
+            "};\n",
+            "",
+        )
+        # A templated *function* (not a lambda) with a redundant trailing
+        # semicolon must still be flagged.
+        self.TestLint(
+            "template <typename T> void f() {};",
+            "You don't need a ; after a }  [readability/braces] [4]",
+        )
+
     def testBraceInitializerList(self):
         self.TestLint("MyStruct p = {1, 2};", "")
         self.TestLint("MyStruct p{1, 2};", "")


### PR DESCRIPTION
Fixes #385.

**Problem:** a C++20 templated lambda like `[]<typename T>(T&& t) { ... };` was falsely flagged `readability/braces` — *"You don't need a ; after a }."*

**Cause:** `CheckTrailingSemicolon` exempts lambdas by checking that the text before `(` ends in `]` (the capture). A templated lambda puts `<T>` between `]` and `(`, so the prefix ends in `>` and the exemption missed it.

**Fix:** also recognise the `]<...>` lambda introducer.

**Testing:**
- templated lambdas (`[]<T>`, `[&]<T>`, multi-param, multi-line, `[]<auto>`) → no longer flagged
- non-templated lambda → still exempted (unchanged)
- real redundant `;` (function / `for` / `while` / `if`, including a templated *function*) → still flagged
- `pytest cpplint_unittest.py` → 206 passed; the new regression tests fail without the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false redundant trailing semicolon warnings for C++20 templated lambdas.
  * Preserved warnings for ordinary templated functions with redundant trailing semicolons.

* **Tests**
  * Added coverage for single-line and multi-line C++20 templated lambda expressions.

* **Documentation**
  * Updated the changelog with details of the warning fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->