### PR TITLE
Mention MegaLinter in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,8 @@ cpplint can also be run as a pre-commit hook by adding this to `.pre-commit-conf
         args:
           - --filter=-whitespace/line_length,-whitespace/parens
 
+cpplint also ships out of the box in `MegaLinter <https://megalinter.io/>`_, an open-source linters aggregator for CI (see its `cpplint documentation <https://megalinter.io/latest/descriptors/c_cpplint/>`_).
+
 Usage
 -----
 .. code-block:: bash

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ cpplint can also be run as a pre-commit hook by adding this to `.pre-commit-conf
         args:
           - --filter=-whitespace/line_length,-whitespace/parens
 
-cpplint also ships out of the box in `MegaLinter <https://megalinter.io/>`_, an open-source linters aggregator for CI (see its `cpplint documentation <https://megalinter.io/latest/descriptors/c_cpplint/>`_).
+cpplint also ships out of the box in `MegaLinter <https://megalinter.io/>`_, an open-source linter aggregator for CI (see its `cpplint documentation <https://megalinter.io/latest/descriptors/c_cpplint/>`_).
 
 Usage
 -----


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI that runs cpplint out of the box, so I figured a short line in the README next to the pre-commit section could help people discover another way to use it. If anything looks off on [our cpplint page](https://megalinter.io/latest/descriptors/c_cpplint/), happy to fix it on our side!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to clarify that cpplint is included by default in MegaLinter.
  * Added links to MegaLinter and its cpplint documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->