### PR TITLE
chore(actions): enforce minimal workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
 on: push
 
+permissions: {}
+
 jobs:
   build:
     name: Build distribution 📦

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,3 +1,0 @@
-rules:
-  excessive-permissions:
-    disable: true


### PR DESCRIPTION
Fixes #466.

## Summary

- deny `GITHUB_TOKEN` permissions by default at the workflow level with `permissions: {}`
- keep the existing explicit job-level permissions required for trusted publishing and GitHub releases
- re-enable zizmor's `excessive-permissions` audit by removing its exclusion from `zizmor.yml`

This follows zizmor's recommended remediation of setting workflow-level permissions to `{}` and granting permissions only to jobs that require them.

The existing SHA pinning and Dependabot cooldown configuration are intentionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved release workflow security by restricting default automation permissions.
  * Enabled detection of excessive permissions in workflow security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->