### PR TITLE
feat: add GitHub Actions output format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 TBA
 ===
 
+* Added a ``--output=github`` format that emits GitHub Actions warning annotations. (#419)
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
 * We now error on relative include paths (``./``, ``../``). (#432)
    * This makes ``#include "./foo.h"`` produce two separate errors: that foo.cpp should include foo.h and that relative paths are not allowed.

--- a/cpplint.py
+++ b/cpplint.py
@@ -63,7 +63,7 @@ _valid_extensions: set[str] = set()
 __VERSION__ = "2.0.3-dev0"
 
 _USAGE = """
-Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]
+Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|github|junit|sed|gsed]
                    [--filter=-x,+y,...]
                    [--counting=total|toplevel|detailed] [--root=subdir]
                    [--repository=path]
@@ -103,11 +103,12 @@ Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]
 
   Flags:
 
-    output=emacs|eclipse|vs7|junit|sed|gsed
+    output=emacs|eclipse|vs7|github|junit|sed|gsed
       By default, the output is formatted to ease emacs parsing.  Visual Studio
       compatible output (vs7) may also be used.  Further support exists for
-      eclipse (eclipse), and JUnit (junit). XML parsers such as those used
-      in Jenkins and Bamboo may also be used.
+      eclipse (eclipse), GitHub Actions annotations (github), and JUnit (junit).
+      XML parsers such as those used in Jenkins and Bamboo may also be used.
+      The github format writes workflow-command warning annotations to stdout.
       The sed format outputs sed commands that should fix some of the errors.
       Note that this requires gnu sed. If that is installed as gsed on your
       system (common e.g. on macOS with homebrew) you can use the gsed output
@@ -372,7 +373,7 @@ _ERROR_CATEGORIES = [
 ]
 
 # keywords to use with --outputs which generate stdout for machine processing
-_MACHINE_OUTPUTS = ["junit", "sed", "gsed"]
+_MACHINE_OUTPUTS = ["github", "junit", "sed", "gsed"]
 
 # These error categories are no longer enforced by cpplint, but for backwards-
 # compatibility they may still appear in NOLINT comments.
@@ -1437,6 +1438,7 @@ class _CppLintState:
         # "eclipse" - format that eclipse can parse
         # "vs7" - format that Microsoft Visual Studio 7 can parse
         # "junit" - format that Jenkins, Bamboo, etc can parse
+        # "github" - GitHub Actions workflow-command annotations
         # "sed" - returns a gnu sed command to fix the problem
         # "gsed" - like sed, but names the command gsed, e.g. for macOS homebrew users
         self.output_format = "emacs"
@@ -1878,6 +1880,16 @@ def _ShouldPrintError(category, confidence, filename, linenum):
     return not is_filtered
 
 
+def _EscapeGithubCommandData(value):
+    """Escapes workflow-command message data for GitHub Actions."""
+    return str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _EscapeGithubCommandProperty(value):
+    """Escapes a workflow-command property value for GitHub Actions."""
+    return _EscapeGithubCommandData(value).replace(":", "%3A").replace(",", "%2C")
+
+
 def Error(filename, linenum, category, confidence, message):
     """Logs the fact we've found a lint error.
 
@@ -1910,6 +1922,13 @@ def Error(filename, linenum, category, confidence, message):
             sys.stderr.write(
                 f"{filename}:{linenum}: warning: {message}  [{category}] [{confidence}]\n"
             )
+        elif _cpplint_state.output_format == "github":
+            properties = f"file={_EscapeGithubCommandProperty(filename)}"
+            if linenum > 0:
+                properties += f",line={linenum}"
+            properties += ",title=cpplint"
+            data = _EscapeGithubCommandData(f"{message}  [{category}] [{confidence}]")
+            sys.stdout.write(f"::warning {properties}::{data}\n")
         elif _cpplint_state.output_format == "junit":
             _cpplint_state.AddJUnitFailure(filename, linenum, message, category, confidence)
         elif _cpplint_state.output_format in ["sed", "gsed"]:
@@ -7831,9 +7850,18 @@ def ParseArguments(args):
         if opt == "--version":
             PrintVersion()
         elif opt == "--output":
-            if val not in ("emacs", "vs7", "eclipse", "junit", "sed", "gsed"):
+            if val not in (
+                "emacs",
+                "vs7",
+                "eclipse",
+                "github",
+                "junit",
+                "sed",
+                "gsed",
+            ):
                 PrintUsage(
-                    "The only allowed output formats are emacs, vs7, eclipse sed, gsed and junit."
+                    "The only allowed output formats are emacs, vs7, eclipse, github, "
+                    "sed, gsed and junit."
                 )
             output_format = val
         elif opt == "--quiet":

--- a/cpplint_clitest.py
+++ b/cpplint_clitest.py
@@ -271,5 +271,20 @@ def test_third_party_headers_config(tmp_path):
     assert b"build/include_subdir" in err
 
 
+def test_github_output(tmp_path):
+    cpp = tmp_path / "test.cpp"
+    cpp.write_text("// Copyright 2026 cpplint\nint main() {\n  return 0; \n}\n")
+
+    status, out, err = run_shell_command(BASE_CMD, "--output=github test.cpp", cwd=str(tmp_path))
+
+    assert status == 1
+    assert err == b""
+    assert out == (
+        b"::warning file=test.cpp,line=3,title=cpplint::"
+        b"Line ends in whitespace.  Consider deleting these extra spaces.  "
+        b"[whitespace/end_of_line] [4]\n"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -7414,5 +7414,10 @@ def run_around_tests(pytestconfig: pytest.Config):
         ErrorCollector(None).VerifyAllCategoriesAreSeen()
 
 
+def test_github_command_escaping():
+    assert cpplint._EscapeGithubCommandData("100%\r\n") == "100%25%0D%0A"
+    assert cpplint._EscapeGithubCommandProperty("a,b:c") == "a%2Cb%3Ac"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Fixes #419.

## Summary

- add `--output=github` support for GitHub Actions annotations
- emit cpplint findings as `::warning` workflow commands
- include file, line, and cpplint title metadata
- escape GitHub Actions command data and properties correctly
- treat GitHub output as machine-readable output on stdout
- document the new output format in the CLI help and changelog
- add CLI regression coverage and unit tests for command escaping

## Testing

- `pytest --no-cov cpplint_clitest.py -k github_output`
- `pytest --no-cov cpplint_unittest.py -k github_command_escaping`
- full test suite: **233 passed**
- total coverage: **96.48%**
- repository pre-commit checks: **passed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--output=github` format that emits GitHub Actions warning annotations.
  * Included file, line, title, and lint category details in generated annotations.
  * Updated command-line help and output format validation to support the new option.

* **Documentation**
  * Added the GitHub output format to the unreleased changelog.

* **Tests**
  * Added coverage for GitHub annotation formatting and special-character escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->