### PR TITLE
Fix structured binding whitespace false negatives 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ TBA
    * This makes ``#include "./foo.h"`` produce two separate errors: that foo.cpp should include foo.h and that relative paths are not allowed.
 * Update and add checks for whitespace before left square brackets. In particular:
    * A single whitespace character is allowed before the left square bracket in structured binding.
-   * No more than one whitespaces character is allowed before the left square bracket, regardless of what character comes before the space (apart from whitespace due to indentation). Previously, whitespace characters were only complained about if they were preceded by a word character.
+   * No more than one whitespace character is allowed before the left square bracket, regardless of what character comes before the space (apart from whitespace due to indentation). Previously, whitespace characters were only complained about if they were preceded by a word character.
 
 2.0.2 (2025-04-08)
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ TBA
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
 * We now error on relative include paths (``./``, ``../``). (#432)
    * This makes ``#include "./foo.h"`` produce two separate errors: that foo.cpp should include foo.h and that relative paths are not allowed.
+* Update and add checks for whitespace before left square brackets. In particular:
+   * A single whitespace character is allowed before the left square bracket in structured binding.
+   * No more than one whitespaces character is allowed before the left square bracket, regardless of what character comes before the space (apart from whitespace due to indentation). Previously, whitespace characters were only complained about if they were preceded by a word character.
 
 2.0.2 (2025-04-08)
 ===========

--- a/cpplint.py
+++ b/cpplint.py
@@ -4401,9 +4401,36 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
     # get rid of comments and strings
     line = clean_lines.elided[linenum]
 
-    # You shouldn't have spaces before your brackets, except for C++11 attributes
-    # or maybe after 'delete []', 'return []() {};', or 'auto [abc, ...] = ...;'.
-    if re.search(r"\w\s+\[(?!\[)", line) and not re.search(r"(?:auto&?|delete|return)\s+\[", line):
+    # Other than due to indentation, you shouldn't have more than one space before
+    # a left square bracket.
+    if re.search(r"\S\s{2,}\[", line):
+        error(filename, linenum, "whitespace/braces", 5, "Extra space before [")
+
+    # After a word character, you shouldn't have any spaces before a left square bracket, except
+    # for:
+    # * before C++11 attributes, in which case the first left square bracket will be immediately
+    #   followed by another;
+    # * after "delete" or "return"; or
+    # * inside of a structured binding, such as `auto const& [abc, ...] = ...;`.
+    #
+    # In these cases, the left square bracket should be preceded by exactly one space. For the
+    # specificatio of structured bindings, see
+    # https://en.cppreference.com/cpp/language/structured_binding.
+    if re.search(r"\w\s\[", line) and not (
+        re.search(r"\w\s\[\[", line)  # Attribute
+        or re.search(r"(?:delete|return)\s\[", line)
+        or re.search(
+            r"""
+(?:((constexpr\s+)|(constint\s+)|(static\s+)|(thread_local\s+)|(const\s+)|(volatile\s+))*)
+auto
+(?:((\s+constexpr)|(\s+constint)|(\s+static)|(\s+thread_local)|(\s+const)|(\s+volatile))*)
+(?:(\&|\&\&)?)
+\s\[
+""",
+            line,
+            re.VERBOSE,
+        )  # Structured binding
+    ):
         error(filename, linenum, "whitespace/braces", 5, "Extra space before [")
 
     # In range-based for, we wanted spaces before and after the colon, but

--- a/cpplint.py
+++ b/cpplint.py
@@ -4416,22 +4416,24 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
     # In these cases, the left square bracket should be preceded by exactly one space. For the
     # specificatio of structured bindings, see
     # https://en.cppreference.com/cpp/language/structured_binding.
-    if re.search(r"\w\s\[", line) and not (
-        re.search(r"\w\s\[\[", line)  # Attribute
-        or re.search(r"(?:delete|return)\s\[", line)
-        or re.search(
-            r"""
+    matches = re.finditer(r"[^\[]*\w\s\[(?!\[)", line)
+    for match in matches:
+        print(f"HERE{match.group()}")
+        if not (
+            re.search(r"(?:delete|return)\s\[", match.group())
+            or re.search(
+                r"""
 (?:((constexpr\s+)|(constint\s+)|(static\s+)|(thread_local\s+)|(const\s+)|(volatile\s+))*)
 auto
 (?:((\s+constexpr)|(\s+constint)|(\s+static)|(\s+thread_local)|(\s+const)|(\s+volatile))*)
 (?:(\&|\&\&)?)
 \s\[
 """,
-            line,
-            re.VERBOSE,
-        )  # Structured binding
-    ):
-        error(filename, linenum, "whitespace/braces", 5, "Extra space before [")
+                match.group(),
+                re.VERBOSE,
+            )  # Structured binding
+        ):
+            error(filename, linenum, "whitespace/braces", 5, "Extra space before [")
 
     # In range-based for, we wanted spaces before and after the colon, but
     # not around "::" tokens that might appear.

--- a/cpplint.py
+++ b/cpplint.py
@@ -4418,7 +4418,6 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
     # https://en.cppreference.com/cpp/language/structured_binding.
     matches = re.finditer(r"[^\[]*\w\s\[(?!\[)", line)
     for match in matches:
-        print(f"HERE{match.group()}")
         if not (
             re.search(r"(?:delete|return)\s\[", match.group())
             or re.search(

--- a/cpplint.py
+++ b/cpplint.py
@@ -4422,9 +4422,9 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
             re.search(r"(?:delete|return)\s\[", match.group())
             or re.search(
                 r"""
-(?:((constexpr\s+)|(constint\s+)|(static\s+)|(thread_local\s+)|(const\s+)|(volatile\s+))*)
+(?:((constexpr\s+)|(constinit\s+)|(static\s+)|(thread_local\s+)|(const\s+)|(volatile\s+))*)
 auto
-(?:((\s+constexpr)|(\s+constint)|(\s+static)|(\s+thread_local)|(\s+const)|(\s+volatile))*)
+(?:((\s+constexpr)|(\s+constinit)|(\s+static)|(\s+thread_local)|(\s+const)|(\s+volatile))*)
 (?:(\&|\&\&)?)
 \s\[
 """,

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3178,6 +3178,7 @@ class TestCpplint(CpplintTestBase):
         self.TestLint("static auto&& [abc, def] = func();", "")
         self.TestLint("auto const&& [abc, def] = func();", "")
         self.TestLint("static auto const&& [abc, def] = func();", "")
+        self.TestLint("auto constinit [x, y] = value;", "")
 
         # multiple spaces not allowed before before braces
         self.TestLint(
@@ -3228,6 +3229,10 @@ class TestCpplint(CpplintTestBase):
         )
         self.TestLint(
             "auto [key, value] = values [index];",
+            "Extra space before [  [whitespace/braces] [5]",
+        )
+        self.TestLint(
+            "auto constinit  [x, y] = value;",
             "Extra space before [  [whitespace/braces] [5]",
         )
 

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3157,10 +3157,75 @@ class TestCpplint(CpplintTestBase):
         self.TestLint(
             "int numbers [] = { 1, 2, 3 };", "Extra space before [  [whitespace/braces] [5]"
         )
-        # space allowed in some cases
-        self.TestLint("auto [abc, def] = func();", "")
+
+        # space due to indentation is allowed
+        self.TestLint("      [[nodiscard]] bool func();", "")
+
+        # single space allowed in some cases
         self.TestLint("#define NODISCARD [[nodiscard]]", "")
         self.TestLint("void foo(int param [[maybe_unused]]);", "")
+        self.TestLint("return [a, b]", "")
+        self.TestLint("delete [c]", "")
+        self.TestLint("auto [abc, def] = func();", "")
+        self.TestLint("static auto [abc, def] = func();", "")
+        self.TestLint("auto const [abc, def] = func();", "")
+        self.TestLint("static auto const [abc, def] = func();", "")
+        self.TestLint("auto& [abc, def] = func();", "")
+        self.TestLint("static auto& [abc, def] = func();", "")
+        self.TestLint("auto const& [abc, def] = func();", "")
+        self.TestLint("static auto const& [abc, def] = func();", "")
+        self.TestLint("auto&& [abc, def] = func();", "")
+        self.TestLint("static auto&& [abc, def] = func();", "")
+        self.TestLint("auto const&& [abc, def] = func();", "")
+        self.TestLint("static auto const&& [abc, def] = func();", "")
+
+        # multiple spaces not allowed before before braces
+        self.TestLint(
+            "#define NODISCARD  [[nodiscard]]", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "void foo(int param  [[maybe_unused]]);",
+            "Extra space before [  [whitespace/braces] [5]",
+        )
+        self.TestLint("return  [a, b]", "Extra space before [  [whitespace/braces] [5]")
+        self.TestLint("delete  [c]", "Extra space before [  [whitespace/braces] [5]")
+        self.TestLint("auto  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]")
+        self.TestLint(
+            "static auto  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "auto const  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "static auto const  [abc, def] = func();",
+            "Extra space before [  [whitespace/braces] [5]",
+        )
+        self.TestLint(
+            "auto&  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "static auto&  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "auto const&  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "static auto const&  [abc, def] = func();",
+            "Extra space before [  [whitespace/braces] [5]",
+        )
+        self.TestLint(
+            "auto&&  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "static auto&&  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "auto const&&  [abc, def] = func();", "Extra space before [  [whitespace/braces] [5]"
+        )
+        self.TestLint(
+            "static auto const&&  [abc, def] = func();",
+            "Extra space before [  [whitespace/braces] [5]",
+        )
 
     def testLambda(self):
         self.TestLint("auto x = []() {};", "")

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3226,6 +3226,10 @@ class TestCpplint(CpplintTestBase):
             "static auto const&&  [abc, def] = func();",
             "Extra space before [  [whitespace/braces] [5]",
         )
+        self.TestLint(
+            "auto [key, value] = values [index];",
+            "Extra space before [  [whitespace/braces] [5]",
+        )
 
     def testLambda(self):
         self.TestLint("auto x = []() {};", "")


### PR DESCRIPTION
Prior to this PR, the line following line failed linting because of "extra space before [  [whitespace/braces] [5]":
```cpp
auto const [abc, def] = func();
```

Additionally, the following line did *not* fail linting:
```cpp
auto&  const [abc, def] = func();
//   ^^ two spaces
```

This PR addresses these by updating the checks for whitespace before left square brackets. In particular:
   * A single whitespace character is allowed before the left square bracket in structured binding, according to [the specification of a structured binding](https://en.cppreference.com/cpp/language/structured_binding).
   * No more than one whitespace character is allowed before the left square bracket, regardless of what character comes before the space (apart from whitespace due to indentation). Previously, whitespace characters were only complained about if they were preceded by a word character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitespace checks before left square brackets.
  * Allows one space in valid C++ attributes, structured bindings, return expressions, and delete expressions.
  * Consistently reports multiple spaces and unnecessary spacing before subscript brackets.
  * Correctly handles structured bindings using the `constinit` qualifier.

* **Tests**
  * Expanded coverage for valid single-space usage and invalid multiple-space formatting.

* **Documentation**
  * Updated the changelog with the revised bracket-spacing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->