### PR TITLE
fix: allow same-directory header includes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 TBA
 ===
 
+* Allow top-level files to include top-level headers without a directory prefix. (#375)
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
 * We now error on relative include paths (``./``, ``../``). (#432)
    * This makes ``#include "./foo.h"`` produce two separate errors: that foo.cpp should include foo.h and that relative paths are not allowed.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 TBA
 ===
 
-* Allow top-level files to include top-level headers without a directory prefix. (#375)
+* Allow source files to include headers from the same directory without a directory prefix. (#375)
 * Fixed a whitespace/newline false positive for control conditions containing lambdas. (#410)
 * We now error on relative include paths (``./``, ``../``). (#432)
    * This makes ``#include "./foo.h"`` produce two separate errors: that foo.cpp should include foo.h and that relative paths are not allowed.

--- a/cpplint.py
+++ b/cpplint.py
@@ -5851,9 +5851,16 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
     # We also make an exception for Lua headers, which follow google
     # naming convention but not the include convention.
     match = re.match(r'#include\s*"([^/]+\.(.*))"', line)
+    same_dir_header = ""
+    if match:
+        same_dir_header = os.path.join(os.path.dirname(fileinfo.FullName()), match.group(1))
     if (
         match
-        and os.path.dirname(fileinfo.RepositoryName())
+        and (
+            not os.path.isfile(same_dir_header)
+            or os.path.normcase(os.path.normpath(same_dir_header))
+            == os.path.normcase(os.path.normpath(fileinfo.FullName()))
+        )
         and IsHeaderExtension(match.group(2))
         and not _third_party_headers_pattern.match(match.group(1))
     ):

--- a/cpplint.py
+++ b/cpplint.py
@@ -5853,6 +5853,7 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
     match = re.match(r'#include\s*"([^/]+\.(.*))"', line)
     if (
         match
+        and os.path.dirname(fileinfo.RepositoryName())
         and IsHeaderExtension(match.group(2))
         and not _third_party_headers_pattern.match(match.group(1))
     ):

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -5831,14 +5831,23 @@ func2();""",
         (repo / ".git").mkdir()
         root_source = repo / "foo.cc"
         root_source.write_text("")
+        root_header = repo / "foo.h"
+        root_header.write_text("")
         source_dir = repo / "src"
         source_dir.mkdir()
         nested_source = source_dir / "foo.cc"
         nested_source.write_text("")
+        same_dir_header = source_dir / "utils.hpp"
+        same_dir_header.write_text("")
 
         self.TestLanguageRulesCheck(
             str(root_source),
             '#include "foo.h"',
+            "",
+        )
+        self.TestLanguageRulesCheck(
+            str(nested_source),
+            '#include "utils.hpp"',
             "",
         )
         self.TestLanguageRulesCheck(

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -5824,13 +5824,30 @@ func2();""",
             cpplint._repository = None
             cpplint._root = None
 
-    def testBuildInclude(self):
+    def testBuildInclude(self, tmp_path):
         # Test that include statements have slashes in them.
-        self.TestLint(
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        root_source = repo / "foo.cc"
+        root_source.write_text("")
+        source_dir = repo / "src"
+        source_dir.mkdir()
+        nested_source = source_dir / "foo.cc"
+        nested_source.write_text("")
+
+        self.TestLanguageRulesCheck(
+            str(root_source),
+            '#include "foo.h"',
+            "",
+        )
+        self.TestLanguageRulesCheck(
+            str(nested_source),
             '#include "foo.h"',
             "Include the directory when naming header files  [build/include_subdir] [4]",
         )
-        self.TestLint(
+        self.TestLanguageRulesCheck(
+            str(nested_source),
             '#include "bar.hh"',
             "Include the directory when naming header files  [build/include_subdir] [4]",
         )

--- a/samples/codelite-sample/simple.def
+++ b/samples/codelite-sample/simple.def
@@ -3,10 +3,9 @@ src/*
 4
 Done processing src/pptable.cpp
 Done processing src/pptable.h
-Total errors found: 675
+Total errors found: 674
 
 src/pptable.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
-src/pptable.cpp:1:  Include the directory when naming header files  [build/include_subdir] [4]
 src/pptable.cpp:6:  { should almost always be at the end of the previous line  [whitespace/braces] [4]
 src/pptable.cpp:7:  Tab found; better to use spaces  [whitespace/tab] [1]
 src/pptable.cpp:8:  Tab found; better to use spaces  [whitespace/tab] [1]

--- a/samples/vlc-sample/simple.def
+++ b/samples/vlc-sample/simple.def
@@ -4,7 +4,7 @@ src/*
 Done processing src/libvlc.c
 Done processing src/libvlc.h
 Done processing src/missing.c
-Total errors found: 600
+Total errors found: 599
 
 src/libvlc.c:40:  Relative paths like . and .. are not allowed.  [build/include] [4]
 src/libvlc.c:41:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
@@ -12,7 +12,6 @@ src/libvlc.c:47:  Found C system header after other header. Should be: libvlc.h,
 src/libvlc.c:48:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:49:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:50:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
-src/libvlc.c:71:  Include the directory when naming header files  [build/include_subdir] [4]
 src/libvlc.c:75:  Found C system header after other header. Should be: libvlc.h, c system, c++ system, other.  [build/include_order] [4]
 src/libvlc.c:86:  Extra space before [  [whitespace/braces] [5]
 src/libvlc.c:86:  Extra space after ( in function call  [whitespace/parens] [4]


### PR DESCRIPTION
Fixes #375.

## Summary

- resolve bare quoted headers against the directory of the file being linted before emitting `build/include_subdir`
- allow a bare include when a different header file actually exists alongside the source, including files under repository subdirectories
- keep `build/include_subdir` enforcement when the bare header does not resolve locally, and keep self-includes subject to the existing warning
- add regression coverage for both repository-root and nested same-directory headers, plus nested missing-header cases
- update affected sample expectations and the unreleased changelog

## Testing

- regression test first reproduced the `src/main.cpp` + `src/utils.hpp` false positive from #375
- `pytest --no-cov cpplint_unittest.py -k testBuildInclude`: passed after the fix
- full test suite: passed
- `pylint cpplint.py`: passed
- repository pre-commit checks: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved include-subdirectory checks for files accessed through symlinks, hard links, and equivalent paths.
  - Prevented false warnings when source files include headers from the same directory without a directory prefix.
  - Corrected self-include detection across equivalent file paths.
  - Updated sample lint reports to reflect the reduced false-positive warning count.

- **Documentation**
  - Clarified changelog wording for same-directory header includes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->